### PR TITLE
Fix random words order for mysql/postgres

### DIFF
--- a/app/controllers/random_words_controller.rb
+++ b/app/controllers/random_words_controller.rb
@@ -5,8 +5,16 @@ class RandomWordsController < ApplicationController
     if RandomWord.count < 2
       @message = "辞書ワードが2件未満です。seedを追加してください。"
       @words = []
-    else
-      @words = RandomWord.order(Arel.sql("RAND()")).limit(2)
+      return
     end
+
+    random_sql =
+      if ActiveRecord::Base.connection.adapter_name.downcase.include?("mysql")
+        "RAND()"
+      else
+        "RANDOM()"
+      end
+
+    @words = RandomWord.order(Arel.sql(random_sql)).limit(2)
   end
 end


### PR DESCRIPTION
デプロイ先で単語が表示されなかった。
辞書ワードが2件未満、seedを追加しての修正。