### PR TITLE
新規登録後にホームへ遷移

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       auto_login(@user)  # 登録したらログイン状態にする（Sorcery）
-      redirect_to root_path, notice: "登録しました"
+      redirect_to ideas_path, notice: "登録しました"
     else
       render :new, status: :unprocessable_entity
     end


### PR DESCRIPTION
新規登録をしたら、トップページに行ってしまうので、ホームに変更