### PR TITLE
Redirect logged-in users from top to ideas

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,4 +1,5 @@
 class TopsController < ApplicationController
   def top
+    redirect_to ideas_path if logged_in?
   end
 end


### PR DESCRIPTION
プライマリURL（/）を開いたとき、ログイン後のトップが表示される  修正