### PR TITLE
Adjust idea list and detail display

### DIFF
--- a/app/controllers/ai_generations_controller.rb
+++ b/app/controllers/ai_generations_controller.rb
@@ -43,23 +43,15 @@ class AiGenerationsController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-  # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def save
     text  = params[:memo].to_s
     word1 = params[:word1].to_s
     word2 = params[:word2].to_s
-    word1_pos = normalize_part_of_speech(params[:word1_pos], default: "noun")
-    word2_pos = normalize_part_of_speech(params[:word2_pos], default: "verb")
-
-    memo = text
-    if word1.present? && word2.present?
-      memo = "元ワード: #{word1}(#{part_of_speech_label(word1_pos)}) / " \
-             "#{word2}(#{part_of_speech_label(word2_pos)})\n\n#{text}"
-    end
 
     idea = current_user.ideas.build(
       title: "#{word1}×#{word2}".presence || "AI生成アイデア",
-      memo: memo
+      memo: text
     )
 
     if idea.save
@@ -78,7 +70,7 @@ class AiGenerationsController < ApplicationController
                     alert: "保存に失敗しました"
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/views/ai_generations/create.turbo_stream.erb
+++ b/app/views/ai_generations/create.turbo_stream.erb
@@ -3,17 +3,30 @@
     <%= @error %>
   <% end %>
 
+  <%= turbo_stream.update "reroll_notice" do %>
+  <% end %>
+
   <%= turbo_stream.update "ai_result" do %>
   <% end %>
 <% else %>
   <%= turbo_stream.update "ai_error" do %>
   <% end %>
 
+  <%= turbo_stream.update "reroll_notice" do %>
+    <p style="margin-bottom: 12px; color: red;">
+      ※再抽選、同じ単語で再作成すると、今の作成結果と編集内容は消えます
+    </p>
+  <% end %>
+
+  <%= turbo_stream.update "generate_button" do %>
+    <%= submit_tag "同じ単語で再作成", data: { disable_with: "生成中..." } %>
+  <% end %>
+
   <%= turbo_stream.update "ai_result" do %>
     <%= form_with url: save_ai_generations_path, method: :post do %>
       <div style="margin-bottom: 12px;">
-        <%= label_tag :memo, "メモ（すぐ編集できます）" %><br>
-        <%= text_area_tag :memo, @text, rows: 12, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
+        <strong style="font-size: 22px;"><%= label_tag :memo, "作成結果メモ（すぐ編集できます）" %></strong><br>
+        <%= text_area_tag :memo, @text, rows: 28, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
       </div>
 
       <%= hidden_field_tag :word1, @word1 %>

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -10,21 +10,39 @@
   <%= link_to "AI作成", random_words_pick_path %>
 </p>
 
-
 <% if @ideas.any? %>
   <% @ideas.each do |idea| %>
     <%= link_to idea_path(idea), class: "text-decoration-none text-dark d-block" do %>
-      <div style="margin-bottom: 16px;">
+      <div style="margin-bottom: 20px; padding: 16px; border: 2px solid #999; border-radius: 16px; background: #f8f8f8;">
         <h2><%= idea.title %></h2>
 
         <% if idea.idea_image&.image? %>
           <div style="margin: 8px 0;">
-            <%= image_tag idea.idea_image.image.url, style: "width: 240px; height: 140px; object-fit: cover; display:block;" %>
+            <%= image_tag idea.idea_image.image.url, style: "width: 240px; height: 140px; object-fit: cover; display: block; border-radius: 12px;" %>
+          </div>
+        <% else %>
+          <div style="width: 240px; height: 140px; margin: 8px 0; border: 2px solid #999; border-radius: 12px; display: flex; align-items: center; justify-content: center; background: #f0f0f0;">
+            画像なし
           </div>
         <% end %>
 
-        <p><%= simple_format(idea.memo) %></p>
-        <small><%= l idea.created_at, format: :short %></small>
+        <% display_memo =
+             if idea.memo.to_s.start_with?("元ワード:")
+               idea.memo.to_s.lines[1..].join.lstrip
+             else
+               idea.memo
+             end %>
+
+        <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;">
+          <%= truncate(display_memo, length: 78) %>
+        </p>
+
+        <p style="margin: 8px 0 0 0; font-size: 14px;">
+          作成日: <%= l idea.created_at, format: :short %>
+          <span style="display: inline-block; margin-left: 24px;">
+            更新日（メモ編集のみ）: <%= l idea.updated_at, format: :short %>
+          </span>
+        </p>
       </div>
     <% end %>
   <% end %>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -61,7 +61,15 @@
 
 <p><%= simple_format(@idea.memo) %></p>
 
-<%= link_to "編集", edit_idea_path(@idea) %>
+<p>
+  <%= link_to "編集", edit_idea_path(@idea) %>
+  <span style="display: inline-block; margin-left: 24px;">
+    作成日: <%= l @idea.created_at, format: :short %>
+  </span>
+  <span style="display: inline-block; margin-left: 24px;">
+    更新日（メモ編集のみ）: <%= l @idea.updated_at, format: :short %>
+  </span>
+</p>
 
 <hr>
 
@@ -70,9 +78,9 @@
 <h3>どこへ移動する？（まず3つから選ぶ）</h3>
 
 <ul>
-  <li><%= link_to "キャラ（要素）詳細ページへ", idea_path(@idea, tab: "elements") %></li>
   <li><%= link_to "ストーリー詳細ページへ", idea_path(@idea, tab: "stories") %></li>
   <li><%= link_to "イベント詳細（メモ一覧）ページへ", idea_path(@idea, tab: "events") %></li>
+  <li><%= link_to "キャラ（要素）詳細ページへ", idea_path(@idea, tab: "elements") %></li>
 </ul>
 
 <% if tab.present? %>

--- a/app/views/random_words/pick.html.erb
+++ b/app/views/random_words/pick.html.erb
@@ -1,26 +1,31 @@
+<%= link_to "戻る", params[:return_to].presence || ideas_path %>
+
 <h1>ランダム辞書ワード</h1>
 
 <% if @words.any? %>
 
   <div id="ai_error" style="color: red;"></div>
-  <div id="ai_result"></div>
 
   <%= form_with url: ai_generations_path, method: :post, data: { turbo_stream: true } do |f| %>
 
-    <p>
-      <%= @words[0].word %>
+    <p style="margin-bottom: 30px;">
+      <span style="display: inline-block; margin-right: 15px;"><%= @words[0].word %></span>
       <%= hidden_field_tag :word1, @words[0].word %>
-      <%= select_tag :word1_pos,
-            options_for_select([["名詞", "noun"], ["動詞", "verb"]], @word1_pos) %>
+      <span style="display: inline-block; margin-right: 15px;">
+        <%= select_tag :word1_pos,
+              options_for_select([["名詞", "noun"], ["動詞", "verb"]], @word1_pos) %>
+      </span>
       <%= check_box_tag :lock_word1, "1", params[:lock_word1] == "1" %>
       固定
     </p>
 
-    <p>
-      <%= @words[1].word %>
+    <p style="margin-bottom: 30px;">
+      <span style="display: inline-block; margin-right: 15px;"><%= @words[1].word %></span>
       <%= hidden_field_tag :word2, @words[1].word %>
-      <%= select_tag :word2_pos,
-            options_for_select([["名詞", "noun"], ["動詞", "verb"]], @word2_pos) %>
+      <span style="display: inline-block; margin-right: 15px;">
+        <%= select_tag :word2_pos,
+              options_for_select([["名詞", "noun"], ["動詞", "verb"]], @word2_pos) %>
+      </span>
       <%= check_box_tag :lock_word2, "1", params[:lock_word2] == "1" %>
       固定
     </p>
@@ -29,12 +34,19 @@
     <%= hidden_field_tag :placeable_type, params[:placeable_type] %>
     <%= hidden_field_tag :placeable_id, params[:placeable_id] %>
 
-    <%= f.submit "AIで生成する", data: { disable_with: "生成中..." } %>
+    <div id="reroll_notice" style="margin-bottom: 12px;"></div>
 
-    <%= f.submit "再抽選",
-          formaction: random_words_pick_path,
-          formmethod: :get %>
+    <div style="margin-bottom: 30px;">
+      <%= f.submit "再抽選",
+            formaction: random_words_pick_path,
+            formmethod: :get %>
+    </div>
 
+    <div id="generate_button" style="margin-top: 0;">
+      <%= f.submit "AIで生成する", data: { disable_with: "生成中..." } %>
+    </div>
+
+    <div id="ai_result" style="margin-top: 30px;"></div>
   <% end %>
 
 <% else %>
@@ -42,5 +54,3 @@
   <p><%= @message %></p>
 
 <% end %>
-
-<%= link_to "一覧へ戻る", ideas_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module App
     config.load_defaults 7.0
 
     config.i18n.default_locale = :ja
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
AI関連の修正
✅全て一覧に戻るになっているので、個別ページに戻るようにする、左上に移動、

✅単語とプルダウン、プルダウンからチェックとの間隔を広げたい

✅単語同士の縦の間隔を広げる

✅再抽選ボタンを上にして、単語との間隔を広げる

✅作成ボタンを下にして、間隔を開ける
✅単語欄をメモの上に交換

✅メモ欄の拡張

✅再抽選ボタンの上に、作成結果が消えることを書く

✅AIで作成するボタンを、AI作成後だけ表記文を変える
- ✅アイデアの作成した時間が違うので修正
- ✅ホームページの元ワードを削除、作成時間削除
- ✅ホームページのアイデア表示の文字数？を制限（パソコン、スマホ）
- ✅画像選択していない場合でも、ホームで画像と同じサイズで画像なしと表示させる
- ✅ホームページのアイデアをカードみたいにしたい（角を丸く）
- ✅どのページのアイデアにも、編集の上に作成日にち入れる。更新日も
- ✅アイデアを確認、作成したり（✅ホーム　✅ストーリー　✅イベント　✅要素）
- ✅AI作成アイデアの編集（✅ホーム　✅ストーリー　✅イベント　✅要素）
- ✅AI作成アイデアの移動（時間などの表記変わってないか）