### PR TITLE
Adjust story screens and title input behavior

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -59,7 +59,7 @@ class StoriesController < ApplicationController
     @story.position = next_position_for(current_user)
 
     if @story.save
-      redirect_to story_path(@story), notice: t(".success")
+      redirect_to stories_path, notice: t(".success")
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/character_counter_controller.js
+++ b/app/javascript/controllers/character_counter_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "output"]
+
+  connect() {
+    this.updateCount()
+  }
+
+  updateCount() {
+    const currentLength = this.inputTarget.value.length
+    const maxLength = this.outputTarget.dataset.maxLength
+
+    this.outputTarget.textContent = `${currentLength} / ${maxLength}文字`
+  }
+}

--- a/app/javascript/controllers/prevent_enter_submit_controller.js
+++ b/app/javascript/controllers/prevent_enter_submit_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  check(event) {
+    if (event.key !== "Enter") return
+
+    const tagName = event.target.tagName.toLowerCase()
+
+    if (tagName === "textarea") return
+
+    event.preventDefault()
+  }
+}

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -15,6 +15,8 @@ class Idea < ApplicationRecord
   # ※任意：現在の移動先を取りたければ（使わなくてもOK）
   # has_one :placeable, through: :idea_placement, source: :placeable
 
-  validates :title, presence: true
+  TITLE_MAX_LENGTH = 40
+
+  validates :title, presence: true, length: { maximum: TITLE_MAX_LENGTH }
   validates :memo, presence: true
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -7,5 +7,7 @@ class Story < ApplicationRecord
   has_many :idea_placements, as: :placeable, dependent: :destroy
   has_many :placed_ideas, through: :idea_placements, source: :idea
 
-  validates :title, presence: true
+  TITLE_MAX_LENGTH = 40
+
+  validates :title, presence: true, length: { maximum: TITLE_MAX_LENGTH }
 end

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: idea, local: true, html: { multipart: true }) do |f| %>
+<%= form_with(model: idea, local: true, html: { multipart: true }, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" }) do |f| %>
   <% if idea.errors.any? %>
     <div class="alert alert-danger">
       <ul class="mb-0">
@@ -9,9 +9,20 @@
     </div>
   <% end %>
 
-  <div style="margin-bottom: 30px;">
-    <%= f.label :title, "タイトル", style: "font-size: 24px; font-weight: bold;" %><br>
-    <%= f.text_field :title, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
+  <div style="margin-bottom: 30px;" data-controller="character-counter">
+    <%= f.label :title, "タイトル（40文字を超えた分は消えます）", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_field :title,
+          maxlength: Idea::TITLE_MAX_LENGTH,
+          data: {
+            "character-counter-target": "input",
+            action: "input->character-counter#updateCount"
+          },
+          style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
+    <div
+      data-character-counter-target="output"
+      data-max-length="<%= Idea::TITLE_MAX_LENGTH %>"
+      style="margin-top: 6px; font-size: 14px; color: #666;"
+    ></div>
   </div>
 
   <div>
@@ -46,7 +57,6 @@
         <div><strong>このアイデアの登場要素（複数選択OK）</strong></div>
 
         <% if @marker_options.present? %>
-          <%# ✅ 全部外した時に空配列を送る %>
           <%= hidden_field_tag "idea[idea_placement_attributes][story_element_ids][]", "" %>
 
           <% selected_ids =

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -40,7 +40,7 @@
         <p style="margin: 8px 0 0 0; font-size: 14px;">
           作成日: <%= l idea.created_at, format: :short %>
           <span style="display: inline-block; margin-left: 24px;">
-            更新日（メモ編集のみ）: <%= l idea.updated_at, format: :short %>
+            更新日（文字編集のみ）: <%= l idea.updated_at, format: :short %>
           </span>
         </p>
       </div>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -67,7 +67,7 @@
     作成日: <%= l @idea.created_at, format: :short %>
   </span>
   <span style="display: inline-block; margin-left: 24px;">
-    更新日（メモ編集のみ）: <%= l @idea.updated_at, format: :short %>
+    更新日（文字編集のみ）: <%= l @idea.updated_at, format: :short %>
   </span>
 </p>
 

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: story do |f| %>
+<%= form_with model: story, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
   <% if story.errors.any? %>
     <ul>
       <% story.errors.full_messages.each do |msg| %>
@@ -7,15 +7,28 @@
     </ul>
   <% end %>
 
-  <div>
-    <%= f.label :title, "タイトル" %><br>
-    <%= f.text_field :title %>
+  <div style="margin-bottom: 30px;" data-controller="character-counter">
+    <%= f.label :title, "タイトル（40文字を超えた分は消えます）", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_field :title,
+          maxlength: Story::TITLE_MAX_LENGTH,
+          data: {
+            "character-counter-target": "input",
+            action: "input->character-counter#updateCount"
+          },
+          style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
+    <div
+      data-character-counter-target="output"
+      data-max-length="<%= Story::TITLE_MAX_LENGTH %>"
+      style="margin-top: 6px; font-size: 14px; color: #666;"
+    ></div>
   </div>
 
   <div>
-    <%= f.label :description, "説明" %><br>
-    <%= f.text_area :description, rows: 5 %>
+    <%= f.label :description, "説明", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_area :description, rows: 28, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
   </div>
 
-  <%= f.submit %>
+  <div style="margin-top: 30px;">
+    <%= f.submit(story.persisted? ? "ストーリーを更新" : "ストーリーを作成") %>
+  </div>
 <% end %>

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,12 +1,10 @@
+<p><%= link_to "戻る", story_path(@story) %></p>
 <h1>ストーリー編集</h1>
 <%= render "form", story: @story %>
 
-<hr>
-
+<p style="margin-top: 50px; color: red; font-weight: bold;">※削除すると中のイベント / 詳細メモ / 要素も消えます。</p>
 <p>
   <%= link_to "このストーリーを削除",
               story_path(@story),
-              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？（中のイベント/詳細メモも消えます）" } %>
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？（中のイベント/詳細メモ/要素も消えます）" } %>
 </p>
-
-<p><%= link_to "戻る", story_path(@story) %></p>

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -1,20 +1,35 @@
-<p><%= link_to "アイデア一覧へ", ideas_path %></p>
+<p><%= link_to "アイデア一覧（ホーム）へ", ideas_path %></p>
 
 <h1>ストーリー一覧</h1>
 
 <p><%= link_to "ストーリー作成", new_story_path %></p>
 
-<ul>
+<% if @stories.any? %>
   <% @stories.each do |story| %>
-    <li>
-      <strong><%= link_to story.title, story_path(story) %></strong><br>
+    <div style="margin-bottom: 20px;">
+      <%= link_to story_path(story), class: "text-decoration-none text-dark d-block" do %>
+        <div style="padding: 16px; border: 2px solid #999; border-radius: 16px; background: #f8f8f8;">
+          <h2><%= story.title %></h2>
 
-      <% if story.description.present? %>
-        <%= simple_format(truncate(story.description, length: 120)) %>
+          <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">
+            <%= truncate(story.description.to_s, length: 78) %>
+          </p>
+        </div>
       <% end %>
 
-      <%= button_to "↑", move_up_story_path(story), method: :patch, form: { style: "display:inline" } %>
-      <%= button_to "↓", move_down_story_path(story), method: :patch, form: { style: "display:inline" } %>
-    </li>
+      <div style="margin-top: 8px;">
+        <span style="display: inline-block; margin-right: 12px;">
+          <%= button_to "↑", move_up_story_path(story), method: :patch, form: { style: "display:inline" } %>
+          <span>上に移動</span>
+        </span>
+
+        <span style="display: inline-block;">
+          <%= button_to "↓", move_down_story_path(story), method: :patch, form: { style: "display:inline" } %>
+          <span>下に移動</span>
+        </span>
+      </div>
+    </div>
   <% end %>
-</ul>
+<% else %>
+  <p>まだストーリーがありません</p>
+<% end %>

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -1,3 +1,3 @@
+<p><%= link_to "戻る", stories_path %></p>
 <h1>ストーリー作成</h1>
 <%= render "form", story: @story %>
-<p><%= link_to "戻る", stories_path %></p>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -24,38 +24,41 @@
 
 <hr>
 
-<%# ✅ 追加：アイデアのマーカー（複数）表示用 %>
-<% marker_labels_for = lambda do |idea| %>
-  <% placement = idea.idea_placement %>
-  <% next "" if placement.blank? %>
-
-  <% labels = [] %>
-  <% if placement.story_elements.present? %>
-    <% placement.story_elements.each do |el| %>
-      <% labels << [el.marker.presence, el.name.presence, el.kind.presence].compact.join(" ") %>
-    <% end %>
-  <% end %>
-
-  <% labels.reject(&:blank?).join(" / ") %>
-<% end %>
-
 <h2>イベント（時系列）</h2>
 
 <p><%= link_to "イベント追加", new_story_story_event_path(@story) %></p>
 
-<ul>
+<% if @story_events.any? %>
   <% @story_events.each do |event| %>
-    <li>
-      <strong><%= link_to event.title, story_story_event_path(@story, event) %></strong><br>
-      <%= simple_format(truncate(event.body.to_s, length: 120)) %>
+    <div style="margin-bottom: 20px;">
+      <%= link_to story_story_event_path(@story, event), class: "text-decoration-none text-dark d-block" do %>
+        <div style="padding: 16px; border: 2px solid #999; border-radius: 16px; background: #f8f8f8;">
+          <h3 style="margin-top: 0;"><%= event.title %></h3>
 
-      <%= button_to "↑", move_up_story_story_event_path(@story, event),
-            method: :patch, form: { style: "display:inline" } %>
-      <%= button_to "↓", move_down_story_story_event_path(@story, event),
-            method: :patch, form: { style: "display:inline" } %>
-    </li>
+          <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">
+            <%= truncate(event.body.to_s, length: 78) %>
+          </p>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 8px;">
+        <span style="display: inline-block; margin-right: 12px;">
+          <%= button_to "↑", move_up_story_story_event_path(@story, event),
+                method: :patch, form: { style: "display:inline" } %>
+          <span>上に移動</span>
+        </span>
+
+        <span style="display: inline-block;">
+          <%= button_to "↓", move_down_story_story_event_path(@story, event),
+                method: :patch, form: { style: "display:inline" } %>
+          <span>下に移動</span>
+        </span>
+      </div>
+    </div>
   <% end %>
-</ul>
+<% else %>
+  <p>まだイベントがありません</p>
+<% end %>
 
 <hr>
 
@@ -69,14 +72,8 @@
 <% if @created_here_ideas.present? %>
   <ul>
     <% @created_here_ideas.each do |idea| %>
-      <% markers = marker_labels_for.call(idea) %>
       <li>
         <%= link_to idea.title, idea_path(idea) %>
-        <% if markers.present? %>
-          <div style="font-size: 0.9em; opacity: 0.85;">
-            <strong>マーカー：</strong><%= markers %>
-          </div>
-        <% end %>
       </li>
     <% end %>
   </ul>
@@ -91,14 +88,8 @@
 <% if @moved_ideas.present? %>
   <ul>
     <% @moved_ideas.each do |idea| %>
-      <% markers = marker_labels_for.call(idea) %>
       <li>
         <%= link_to idea.title, idea_path(idea) %>
-        <% if markers.present? %>
-          <div style="font-size: 0.9em; opacity: 0.85;">
-            <strong>マーカー：</strong><%= markers %>
-          </div>
-        <% end %>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
- 🔰⬇️Ⓜ️🅰ストーリー一覧
- ✅アイデアのタイトルの文字数制限、カウント
- ✅ストーリー作成の入力欄拡張
- ✅タイトルで、エンター押すとエラー出るor保存されるので修正
- ✅ストーリー作成のタイトルに文字数制限とカウント
- ✅戻るリンクを**ストーリー作成の上にする**
- ✅ストーリー新規作成後、ストーリー一覧に戻るようにする
- 🔰⬇️Ⓜ️🅰ストーリー詳細
- ✅アイデアの表示マーカーいらない
- ✅イベントに、カード要素をつける
- ストーリー編集
- ✅戻るボタンを編集の上
- ✅ストーリーを作成ではなく、ストーリーを更新
- ✅削除の上に、注意文