### PR TITLE
Add image upload to stories and events

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -50,17 +50,22 @@ class StoriesController < ApplicationController
 
   def new
     @story = current_user.stories.new
+    @story.build_story_image if @story.story_image.nil?
   end
 
-  def edit; end
+  def edit
+    @story.build_story_image if @story.story_image.nil?
+  end
 
   def create
     @story = current_user.stories.new(story_params)
+    @story.build_story_image if @story.story_image.nil?
     @story.position = next_position_for(current_user)
 
     if @story.save
       redirect_to stories_path, notice: t(".success")
     else
+      @story.build_story_image if @story.story_image.nil?
       render :new, status: :unprocessable_entity
     end
   end
@@ -69,6 +74,7 @@ class StoriesController < ApplicationController
     if @story.update(story_params)
       redirect_to story_path(@story), notice: t(".success")
     else
+      @story.build_story_image if @story.story_image.nil?
       render :edit, status: :unprocessable_entity
     end
   end
@@ -122,7 +128,10 @@ class StoriesController < ApplicationController
   end
 
   def story_params
-    params.require(:story).permit(:title, :description)
+    params.require(:story).permit(
+      :title, :description,
+      story_image_attributes: %i[id image image_cache remove_image]
+    )
   end
 
   def swap_positions(first_record, second_record)

--- a/app/controllers/story_event_ideas_controller.rb
+++ b/app/controllers/story_event_ideas_controller.rb
@@ -2,7 +2,9 @@
 class StoryEventIdeasController < ApplicationController
   before_action :require_login
   before_action :set_story_and_event
-  before_action :set_story_event_idea, only: %i[edit update destroy move_up move_down]
+  before_action :set_story_event_idea, only: %i[show edit update destroy move_up move_down]
+
+  def show; end
 
   def new
     @story_event_idea = @story_event.story_event_ideas.new
@@ -18,6 +20,8 @@ class StoryEventIdeasController < ApplicationController
 
   def create
     @story_event_idea = @story_event.story_event_ideas.new(story_event_idea_params)
+    @story_event_idea.position = next_position_for(@story_event)
+
     if @story_event_idea.save
       redirect_to story_story_event_path(@story, @story_event), notice: t("flash.story_event_ideas.created")
     else
@@ -87,5 +91,9 @@ class StoryEventIdeasController < ApplicationController
         idea.update!(position: i + 1)
       end
     end
+  end
+
+  def next_position_for(story_event)
+    (story_event.story_event_ideas.maximum(:position) || 0) + 10
   end
 end

--- a/app/controllers/story_events_controller.rb
+++ b/app/controllers/story_events_controller.rb
@@ -23,17 +23,22 @@ class StoryEventsController < ApplicationController
 
   def new
     @story_event = @story.story_events.new
+    @story_event.build_story_event_image if @story_event.story_event_image.nil?
   end
 
-  def edit; end
+  def edit
+    @story_event.build_story_event_image if @story_event.story_event_image.nil?
+  end
 
   def create
     @story_event = @story.story_events.new(story_event_params)
+    @story_event.build_story_event_image if @story_event.story_event_image.nil?
     @story_event.position = next_position_for(@story)
 
     if @story_event.save
       redirect_to story_path(@story), notice: t(".success")
     else
+      @story_event.build_story_event_image if @story_event.story_event_image.nil?
       render :new, status: :unprocessable_entity
     end
   end
@@ -42,6 +47,7 @@ class StoryEventsController < ApplicationController
     if @story_event.update(story_event_params)
       redirect_to story_path(@story), notice: t(".success")
     else
+      @story_event.build_story_event_image if @story_event.story_event_image.nil?
       render :edit, status: :unprocessable_entity
     end
   end
@@ -98,6 +104,7 @@ class StoryEventsController < ApplicationController
   def story_event_params
     params.require(:story_event).permit(
       :title, :body,
+      story_event_image_attributes: %i[id image image_cache remove_image],
       story_element_ids: []
     )
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -3,6 +3,9 @@ class Story < ApplicationRecord
   has_many :story_events, dependent: :destroy
   has_many :story_elements, dependent: :destroy
 
+  has_one :story_image, dependent: :destroy
+  accepts_nested_attributes_for :story_image, update_only: true
+
   # ✅ 追加（このストーリーに「移動してきたアイデア」をぶら下げる）
   has_many :idea_placements, as: :placeable, dependent: :destroy
   has_many :placed_ideas, through: :idea_placements, source: :idea

--- a/app/models/story_event.rb
+++ b/app/models/story_event.rb
@@ -6,6 +6,9 @@ class StoryEvent < ApplicationRecord
   has_many :story_event_elements, dependent: :destroy
   has_many :story_elements, through: :story_event_elements
 
+  has_one :story_event_image, dependent: :destroy
+  accepts_nested_attributes_for :story_event_image, update_only: true
+
   # ✅ 追加（このイベントに「移動してきたアイデア」をぶら下げる）
   has_many :idea_placements, as: :placeable, dependent: :destroy
   has_many :placed_ideas, through: :idea_placements, source: :idea

--- a/app/models/story_event_image.rb
+++ b/app/models/story_event_image.rb
@@ -1,0 +1,5 @@
+class StoryEventImage < ApplicationRecord
+  belongs_to :story_event
+
+  mount_uploader :image, IdeaImageUploader
+end

--- a/app/models/story_image.rb
+++ b/app/models/story_image.rb
@@ -1,0 +1,5 @@
+class StoryImage < ApplicationRecord
+  belongs_to :story
+
+  mount_uploader :image, IdeaImageUploader
+end

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -42,7 +42,7 @@
   %>
 
   <div style="margin: 12px 0;">
-    <strong>マーカー：</strong>
+    <strong>登場要素：</strong>
     <ul style="margin: 8px 0;">
       <% elements.each do |el| %>
         <% label = [el.marker.presence, el.name.presence, el.kind.presence].compact.join(" ") %>
@@ -75,7 +75,7 @@
 
 <% tab = params[:tab].presence || @tab %>
 
-<h3>どこへ移動する？（まず3つから選ぶ）</h3>
+<h3>このアイデアどこへ移動する？（まず3つから選ぶ）</h3>
 
 <ul>
   <li><%= link_to "ストーリー詳細ページへ", idea_path(@idea, tab: "stories") %></li>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: story, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
+<%= form_with model: story, html: { multipart: true }, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
   <% if story.errors.any? %>
     <ul>
       <% story.errors.full_messages.each do |msg| %>
@@ -27,6 +27,21 @@
     <%= f.label :description, "説明", style: "font-size: 24px; font-weight: bold;" %><br>
     <%= f.text_area :description, rows: 28, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
   </div>
+
+  <%= f.fields_for :story_image do |imgf| %>
+    <%= imgf.hidden_field :id if imgf.object&.persisted? %>
+
+    <div style="margin-top: 16px;">
+      <%= imgf.label :image, "画像（任意）" %><br>
+      <%= imgf.file_field :image %>
+
+      <% if story.story_image&.image? %>
+        <div style="margin-top: 8px;">
+          <%= image_tag story.story_image.image.url, style: "max-width: 320px; height: auto;" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
   <div style="margin-top: 30px;">
     <%= f.submit(story.persisted? ? "ストーリーを更新" : "ストーリーを作成") %>

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -2,9 +2,9 @@
 <h1>ストーリー編集</h1>
 <%= render "form", story: @story %>
 
-<p style="margin-top: 50px; color: red; font-weight: bold;">※削除すると中のイベント / 詳細メモ / 要素も消えます。</p>
+<p style="margin-top: 50px; color: red; font-weight: bold;">※削除すると中のイベント / 詳細メモ / 要素 / 関連アイデアも消えます。</p>
 <p>
   <%= link_to "このストーリーを削除",
               story_path(@story),
-              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？（中のイベント/詳細メモ/要素も消えます）" } %>
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？（中のイベント/詳細メモ/要素/関連アイデアも消えます）" } %>
 </p>

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -11,6 +11,12 @@
         <div style="padding: 16px; border: 2px solid #999; border-radius: 16px; background: #f8f8f8;">
           <h2><%= story.title %></h2>
 
+          <% if story.story_image&.image? %>
+            <div style="margin: 8px 0;">
+              <%= image_tag story.story_image.image.url, style: "width: 240px; height: 140px; object-fit: cover; display: block; border-radius: 12px;" %>
+            </div>
+          <% end %>
+
           <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">
             <%= truncate(story.description.to_s, length: 78) %>
           </p>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -2,6 +2,13 @@
 
 <h1><%= @story.title %></h1>
 
+<% if @story.story_image&.image? %>
+  <div style="margin-top: 16px;">
+    <%= image_tag @story.story_image.image.url, style: "max-width: 320px; height: auto;" %>
+  </div>
+<% end %>
+
+<h2>説明</h2>
 <% if @story.description.present? %>
   <div>
     <%= simple_format(@story.description) %>
@@ -34,6 +41,12 @@
       <%= link_to story_story_event_path(@story, event), class: "text-decoration-none text-dark d-block" do %>
         <div style="padding: 16px; border: 2px solid #999; border-radius: 16px; background: #f8f8f8;">
           <h3 style="margin-top: 0;"><%= event.title %></h3>
+
+          <% if event.story_event_image&.image? %>
+            <div style="margin: 8px 0;">
+              <%= image_tag event.story_event_image.image.url, style: "width: 240px; height: 140px; object-fit: cover; display: block; border-radius: 12px;" %>
+            </div>
+          <% end %>
 
           <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">
             <%= truncate(event.body.to_s, length: 78) %>

--- a/app/views/story_event_ideas/_form.html.erb
+++ b/app/views/story_event_ideas/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [@story, @story_event, @story_event_idea], local: true do |f| %>
+<%= form_with model: [@story, @story_event, @story_event_idea], data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
   <% if @story_event_idea.errors.any? %>
     <ul>
       <% @story_event_idea.errors.full_messages.each do |msg| %>
@@ -7,36 +7,57 @@
     </ul>
   <% end %>
 
-  <div>
-    <%= f.label :title, "タイトル" %><br>
-    <%= f.text_field :title %>
+  <div style="margin-bottom: 30px;" data-controller="character-counter">
+    <%= f.label :title, "タイトル（40文字を超えた分は入力できません）", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_field :title,
+          maxlength: 40,
+          data: {
+            "character-counter-target": "input",
+            action: "input->character-counter#updateCount"
+          },
+          style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
+    <div
+      data-character-counter-target="output"
+      data-max-length="40"
+      style="margin-top: 6px; font-size: 14px; color: #666;"
+    ></div>
   </div>
 
-  <div>
-    <%= f.label :memo, "メモ" %><br>
-    <%= f.text_area :memo, rows: 8 %>
+  <div style="margin-bottom: 30px;">
+    <%= f.label :memo, "メモ", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_area :memo, rows: 28, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
   </div>
 
-  <div>
-    <%= f.label :image, "画像（任意）" %><br>
+  <div style="margin-bottom: 30px;">
+    <%= f.label :image, "画像（任意）", style: "font-size: 24px; font-weight: bold;" %><br>
     <%= f.file_field :image %>
+
+    <% if @story_event_idea.image? %>
+      <div style="margin-top: 8px;">
+        <%= image_tag @story_event_idea.image.url, style: "max-width: 320px; height: auto;" %>
+      </div>
+    <% end %>
   </div>
 
-  <div>
-    <%= f.label :story_element_ids, "このメモの登場要素" %><br>
+  <div style="margin-bottom: 30px;">
+    <div style="font-size: 24px; font-weight: bold;">このメモの登場要素</div>
 
     <% if @story.story_elements.any? %>
-      <%= f.collection_check_boxes :story_element_ids, @story.story_elements, :id,
-                                   ->(el) { story_element_label(el) } do |b| %>
-        <div>
-          <%= b.check_box %>
-          <%= b.label %>
-        </div>
-      <% end %>
+      <div style="margin-top: 12px;">
+        <%= f.collection_check_boxes :story_element_ids, @story.story_elements, :id,
+                                     ->(el) { story_element_label(el) } do |b| %>
+          <div>
+            <%= b.check_box %>
+            <%= b.label %>
+          </div>
+        <% end %>
+      </div>
     <% else %>
       <p>登場要素がまだありません（先に要素を作成してください）</p>
     <% end %>
   </div>
 
-  <%= f.submit "保存" %>
+  <div style="margin-top: 24px;">
+    <%= f.submit "詳細メモを追加する" %>
+  </div>
 <% end %>

--- a/app/views/story_event_ideas/new.html.erb
+++ b/app/views/story_event_ideas/new.html.erb
@@ -1,7 +1,9 @@
+<p>
+  <%= link_to "戻る", story_story_event_path(@story, @story_event) %>
+</p>
+
 <h1>詳細メモ追加</h1>
 
 <%= render "form" %>
 
-<p>
-  <%= link_to "戻る", story_story_event_path(@story, @story_event) %>
-</p>
+

--- a/app/views/story_event_ideas/show.html.erb
+++ b/app/views/story_event_ideas/show.html.erb
@@ -1,0 +1,32 @@
+<p>
+  <%= link_to "イベントへ戻る", story_story_event_path(@story, @story_event) %>
+</p>
+
+<h1><%= @story_event_idea.title %></h1>
+
+<h4>詳細メモの登場要素</h4>
+<% if @story_event_idea.story_elements.any? %>
+  <ul>
+    <% @story_event_idea.story_elements.each do |el| %>
+      <li><%= story_element_label(el) %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>未設定</p>
+<% end %>
+
+<% if @story_event_idea.image.present? %>
+  <h4>画像</h4>
+  <div>
+    <%= image_tag @story_event_idea.image.url, style: "max-width: 100%; height: auto;" %>
+  </div>
+<% end %>
+
+<h4>説明</h4>
+<div>
+  <%= simple_format(@story_event_idea.memo) %>
+</div>
+
+<p>
+  <%= link_to "編集", edit_story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea) %>
+</p>

--- a/app/views/story_events/_form.html.erb
+++ b/app/views/story_events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [@story, @story_event] do |f| %>
+<%= form_with model: [@story, @story_event], html: { multipart: true }, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
   <% if @story_event.errors.any? %>
     <ul>
       <% @story_event.errors.full_messages.each do |msg| %>
@@ -7,31 +7,61 @@
     </ul>
   <% end %>
 
-  <div>
-    <%= f.label :title, "タイトル" %><br>
-    <%= f.text_field :title %>
+  <div style="margin-bottom: 30px;" data-controller="character-counter">
+    <%= f.label :title, "タイトル（40文字を超えた分は入力できません）", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_field :title,
+          maxlength: 40,
+          data: {
+            "character-counter-target": "input",
+            action: "input->character-counter#updateCount"
+          },
+          style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
+    <div
+      data-character-counter-target="output"
+      data-max-length="40"
+      style="margin-top: 6px; font-size: 14px; color: #666;"
+    ></div>
   </div>
 
-  <div>
-    <%= f.label :body, "説明" %><br>
-    <%= f.text_area :body, rows: 5 %>
+  <div style="margin-bottom: 30px;">
+    <%= f.label :body, "説明", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_area :body, rows: 28, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
   </div>
 
-  <div>
-    <%= f.label :story_element_ids, "登場要素" %><br>
+  <%= f.fields_for :story_event_image do |imgf| %>
+    <%= imgf.hidden_field :id if imgf.object&.persisted? %>
 
-    <% if @story.story_elements.any? %>
-      <%= f.collection_check_boxes :story_element_ids, @story.story_elements, :id,
-                                   ->(el) { story_element_label(el) } do |b| %>
-        <div>
-          <%= b.check_box %>
-          <%= b.label %>
+    <div style="margin-bottom: 30px;">
+      <%= imgf.label :image, "画像（任意）", style: "font-size: 24px; font-weight: bold;" %><br>
+      <%= imgf.file_field :image %>
+
+      <% if @story_event.story_event_image&.image? %>
+        <div style="margin-top: 8px;">
+          <%= image_tag @story_event.story_event_image.image.url, style: "max-width: 320px; height: auto;" %>
         </div>
       <% end %>
+    </div>
+  <% end %>
+
+  <div style="margin-bottom: 30px;">
+    <%= f.label :story_element_ids, "登場要素", style: "font-size: 24px; font-weight: bold;" %><br>
+
+    <% if @story.story_elements.any? %>
+      <div style="margin-top: 12px;">
+        <%= f.collection_check_boxes :story_element_ids, @story.story_elements, :id,
+                                     ->(el) { story_element_label(el) } do |b| %>
+          <div>
+            <%= b.check_box %>
+            <%= b.label %>
+          </div>
+        <% end %>
+      </div>
     <% else %>
       <p>登場要素がまだありません（先に要素を作成してください）</p>
     <% end %>
   </div>
 
-  <%= f.submit %>
+  <div style="margin-top: 24px;">
+    <%= f.submit "イベントを更新する" %>
+  </div>
 <% end %>

--- a/app/views/story_events/edit.html.erb
+++ b/app/views/story_events/edit.html.erb
@@ -1,7 +1,14 @@
+<%= link_to "戻る", story_story_event_path(@story, @story_event) %>
 <h1>イベント編集</h1>
 <%= render "form" %>
-<%= button_to "削除",
-      story_story_event_path(@story, @story_event),
-      method: :delete,
-      data: { turbo_confirm: "本当に削除しますか？" } %>
-<%= link_to "戻る", story_story_event_path(@story, @story_event) %>
+
+<div style="margin-top: 16px;">
+  <p style="color: red; margin-bottom: 8px;">
+    ※削除すると中の詳細メモ・関連アイデアも消えます。
+  </p>
+
+  <%= button_to "削除",
+        story_story_event_path(@story, @story_event),
+        method: :delete,
+        data: { turbo_confirm: "本当に削除しますか？（中の/詳細メモ/関連アイデアも消えます）" } %>
+</div>

--- a/app/views/story_events/new.html.erb
+++ b/app/views/story_events/new.html.erb
@@ -1,3 +1,3 @@
+<p><%= link_to "戻る", story_path(@story) %></p>
 <h1>イベント追加</h1>
 <%= render "form" %>
-<p><%= link_to "戻る", story_path(@story) %></p>

--- a/app/views/story_events/show.html.erb
+++ b/app/views/story_events/show.html.erb
@@ -1,12 +1,14 @@
 <p>
-  <%= link_to "イベントへ戻る", story_path(@story) %> 
+  <%= link_to "ストーリー詳細へ戻る", story_path(@story) %> 
 </p>
 
 <h1><%= @story_event.title %></h1>
 
-<div>
-  <%= simple_format(@story_event.body) %>
-</div>
+<% if @story_event.story_event_image&.image? %>
+  <div style="margin-top: 16px;">
+    <%= image_tag @story_event.story_event_image.image.url, style: "max-width: 320px; height: auto;" %>
+  </div>
+<% end %>
 
 <h4>イベントの登場要素</h4>
 <% if @story_event.story_elements.any? %>
@@ -18,6 +20,11 @@
 <% else %>
   <p>未設定</p>
 <% end %>
+
+<h4>説明</h4>
+<div>
+  <%= simple_format(@story_event.body) %>
+</div>
 
 <p>
   <%= link_to "編集", edit_story_story_event_path(@story, @story_event) %>
@@ -33,36 +40,39 @@
 
 <% if @story_event.story_event_ideas.any? %>
   <% @story_event.story_event_ideas.order(:position, :created_at).each do |idea| %>
-    <div style="margin-bottom: 24px;">
-      <h3><%= idea.title %></h3>
+    <%= link_to story_story_event_story_event_idea_path(@story, @story_event, idea),
+                style: "display: block; margin-bottom: 8px; border: 2px solid #999; border-radius: 20px; padding: 24px; background-color: #f3f3f3; color: inherit; text-decoration: none;" do %>
+      <h3 style="margin-top: 0; margin-bottom: 16px; text-decoration: underline;">
+        <%= idea.title %>
+      </h3>
 
-      <% if idea.image.present? %>
-        <%= image_tag idea.image.url, style: "max-width: 100%; height: auto;" %>
+      <% if idea.image? %>
+        <div style="margin: 8px 0 12px 0;">
+          <%= image_tag idea.image.url, style: "width: 240px; height: 140px; object-fit: cover; display: block; border-radius: 12px;" %>
+        </div>
       <% end %>
 
-      <div>
-        <%= simple_format(idea.memo) %>
-      </div>
-
-      <div>
-        <strong>このメモの登場要素：</strong>
-        <% if idea.story_elements.any? %>
-          <%= idea.story_elements.map { |el| story_element_label(el) }.join(" / ") %>
-        <% else %>
-          <span>未設定</span>
-        <% end %>
-      </div>
-
-      <p>
-        <%= link_to "↑",
-                    move_up_story_story_event_story_event_idea_path(@story, @story_event, idea),
-                    data: { turbo_method: :patch } %>
-        <%= link_to "↓",
-                    move_down_story_story_event_story_event_idea_path(@story, @story_event, idea),
-                    data: { turbo_method: :patch } %>
-        |
-        <%= link_to "編集", edit_story_story_event_story_event_idea_path(@story, @story_event, idea) %>
+      <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">
+        <%= truncate(idea.memo.to_s, length: 78) %>
       </p>
+    <% end %>
+
+    <div style="margin-top: 0; margin-bottom: 24px; display: flex; gap: 16px; align-items: center;">
+      <div style="display: flex; align-items: center; gap: 6px;">
+        <%= button_to "↑",
+                      move_up_story_story_event_story_event_idea_path(@story, @story_event, idea),
+                      method: :patch,
+                      form: { style: "display: inline;" } %>
+        <span>上に移動</span>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 6px;">
+        <%= button_to "↓",
+                      move_down_story_story_event_story_event_idea_path(@story, @story_event, idea),
+                      method: :patch,
+                      form: { style: "display: inline;" } %>
+        <span>下に移動</span>
+      </div>
     </div>
   <% end %>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
       end
 
       # ✅ イベント詳細メモ（アイデア形式）＋ 並び替え
-      resources :story_event_ideas, only: %i[new create edit update destroy] do
+      resources :story_event_ideas, only: %i[show new create edit update destroy] do
         member do
           patch :move_up
           patch :move_down

--- a/db/migrate/20260318044811_create_story_images.rb
+++ b/db/migrate/20260318044811_create_story_images.rb
@@ -1,0 +1,10 @@
+class CreateStoryImages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :story_images do |t|
+      t.references :story, null: false, foreign_key: true, index: { unique: true }
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260318044828_create_story_event_images.rb
+++ b/db/migrate/20260318044828_create_story_event_images.rb
@@ -1,0 +1,10 @@
+class CreateStoryEventImages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :story_event_images do |t|
+      t.references :story_event, null: false, foreign_key: true, index: { unique: true }
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_09_041951) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_18_044828) do
   create_table "idea_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "idea_id", null: false
     t.string "image"
@@ -122,6 +122,14 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_09_041951) do
     t.index ["story_event_id"], name: "index_story_event_ideas_on_story_event_id"
   end
 
+  create_table "story_event_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "story_event_id", null: false
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["story_event_id"], name: "index_story_event_images_on_story_event_id", unique: true
+  end
+
   create_table "story_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "story_id", null: false
     t.string "title", null: false
@@ -131,6 +139,14 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_09_041951) do
     t.datetime "updated_at", null: false
     t.index ["story_id", "position"], name: "index_story_events_on_story_id_and_position"
     t.index ["story_id"], name: "index_story_events_on_story_id"
+  end
+
+  create_table "story_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "story_id", null: false
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["story_id"], name: "index_story_images_on_story_id", unique: true
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -160,5 +176,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_09_041951) do
   add_foreign_key "story_event_idea_elements", "story_event_ideas"
   add_foreign_key "story_event_ideas", "ideas"
   add_foreign_key "story_event_ideas", "story_events"
+  add_foreign_key "story_event_images", "story_events"
   add_foreign_key "story_events", "stories"
+  add_foreign_key "story_images", "stories"
 end

--- a/spec/factories/story_event_images.rb
+++ b/spec/factories/story_event_images.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :story_event_image do
+    story_event { nil }
+    image { "MyString" }
+  end
+end

--- a/spec/factories/story_images.rb
+++ b/spec/factories/story_images.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :story_image do
+    story { nil }
+    image { "MyString" }
+  end
+end

--- a/spec/models/story_event_image_spec.rb
+++ b/spec/models/story_event_image_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe StoryEventImage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/story_image_spec.rb
+++ b/spec/models/story_image_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe StoryImage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- イベント一覧
- ✅詳細メモの登場要素をなくす
- ✅イベントの説明を**イベントの登場要素の下にする**
- ✅アイデア詳細のマーカーを登場要素にする
- ✅詳細メモを移動はできない、アイデアのようにしたい。
- ✅編集リンクをなくす
- ✅イベントへ戻るではなく、ストーリー詳細に戻る
- ✅詳細メモをカードにする
- ✅詳細メモの並び替えボタン
- ✅ストーリーページのアイデアの説明の表示数指定

✅ホームアイデア　78文字＋3行制限

✅ストーリー一覧　78文字＋3行制限

✅ストーリーページのイベント　78文字＋3行制限

✅イベントページの詳細メモ　入ってなかったので、78文字＋3行制限をつけた

- ✅イベント新規作成の拡張、イベントを追加するボタン
- ✅イベント新規作成、イベント作成のタイトルに文字数制限、カウント
- ✅タイトルで、エンター押すとエラー出るor保存されるので修正
- 🔰⬇️Ⓜ️🅰イベント詳細
- ✅詳細メモが、新規は下にでるようになっていないので修正
- ✅イベント詳細メモ作成の欄を拡張
- ✅イベント詳細作成のタイトルの文字数制限、カウント
- ✅タイトルで、エンター押すとエラー出るor保存されるので修正
- イベント編集
- ✅削除リンク上に注意文※
- ✅削除リンク押した後の注意文

✅ストーリーやイベントに画像機能つける

✅ストーリーの新規と編集（説明の下）

✅イベントの新規と編集（登場要素選択のうえ）

✅さらに、ストーリー一覧にも画像見れるようにしたい

✅ちなみに、イベント詳細メモについては大丈夫？