### PR TITLE
Fix story event memo display and redirects

### DIFF
--- a/app/controllers/story_event_ideas_controller.rb
+++ b/app/controllers/story_event_ideas_controller.rb
@@ -31,7 +31,8 @@ class StoryEventIdeasController < ApplicationController
 
   def update
     if @story_event_idea.update(story_event_idea_params)
-      redirect_to story_story_event_path(@story, @story_event), notice: t("flash.story_event_ideas.updated")
+      redirect_to story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea),
+                  notice: t("flash.story_event_ideas.updated")
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/story_events_controller.rb
+++ b/app/controllers/story_events_controller.rb
@@ -45,7 +45,7 @@ class StoryEventsController < ApplicationController
 
   def update
     if @story_event.update(story_event_params)
-      redirect_to story_path(@story), notice: t(".success")
+      redirect_to story_story_event_path(@story, @story_event), notice: t(".success")
     else
       @story_event.build_story_event_image if @story_event.story_event_image.nil?
       render :edit, status: :unprocessable_entity

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -15,6 +15,10 @@
             <div style="margin: 8px 0;">
               <%= image_tag story.story_image.image.url, style: "width: 240px; height: 140px; object-fit: cover; display: block; border-radius: 12px;" %>
             </div>
+          <% else %>
+            <div style="width: 240px; height: 140px; margin: 8px 0; border: 2px solid #999; border-radius: 12px; display: flex; align-items: center; justify-content: center; background: #f0f0f0;">
+              画像なし
+            </div>
           <% end %>
 
           <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -46,6 +46,10 @@
             <div style="margin: 8px 0;">
               <%= image_tag event.story_event_image.image.url, style: "width: 240px; height: 140px; object-fit: cover; display: block; border-radius: 12px;" %>
             </div>
+          <% else %>
+            <div style="width: 240px; height: 140px; margin: 8px 0; border: 2px solid #999; border-radius: 12px; display: flex; align-items: center; justify-content: center; background: #f0f0f0;">
+              画像なし
+            </div>
           <% end %>
 
           <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">

--- a/app/views/story_event_ideas/_form.html.erb
+++ b/app/views/story_event_ideas/_form.html.erb
@@ -58,6 +58,6 @@
   </div>
 
   <div style="margin-top: 24px;">
-    <%= f.submit "詳細メモを追加する" %>
+    <%= f.submit @story_event_idea.persisted? ? "詳細メモを更新する" : "詳細メモを追加する" %>
   </div>
 <% end %>

--- a/app/views/story_event_ideas/edit.html.erb
+++ b/app/views/story_event_ideas/edit.html.erb
@@ -1,15 +1,14 @@
+<p>
+  <%= link_to "戻る", story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea) %>
+</p>
+
 <h1>詳細メモ編集</h1>
 
 <%= render "form" %>
 
-<hr>
-
+<p style="margin-top: 50px; color: red; font-weight: bold;">※削除すると中の/ 関連アイデアも消えます。</p>
 <p>
   <%= link_to "削除",
               story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea),
-              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
-</p>
-
-<p>
-  <%= link_to "戻る", story_story_event_path(@story, @story_event) %>
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？中の/ 関連アイデアも消えます。" } %>
 </p>

--- a/app/views/story_event_ideas/show.html.erb
+++ b/app/views/story_event_ideas/show.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= link_to "イベントへ戻る", story_story_event_path(@story, @story_event) %>
+  <%= link_to "イベント詳細へ戻る", story_story_event_path(@story, @story_event) %>
 </p>
 
 <h1><%= @story_event_idea.title %></h1>

--- a/app/views/story_events/show.html.erb
+++ b/app/views/story_events/show.html.erb
@@ -50,6 +50,10 @@
         <div style="margin: 8px 0 12px 0;">
           <%= image_tag idea.image.url, style: "width: 240px; height: 140px; object-fit: cover; display: block; border-radius: 12px;" %>
         </div>
+      <% else %>
+        <div style="width: 240px; height: 140px; margin: 8px 0 12px 0; border: 2px solid #999; border-radius: 12px; display: flex; align-items: center; justify-content: center; background: #f0f0f0;">
+          画像なし
+        </div>
       <% end %>
 
       <p style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; margin-bottom: 0;">


### PR DESCRIPTION
- ✅どのページにも、ホームと同じように画像なしでも、画像欄が表示されるようにしたい
- 🔰⬇️Ⓜ️🅰詳細
- 🔰⬇️Ⓜ️🅰編集
- ✅新規さくせい、編集移動先　イベント（更新）　イベント詳細（更新）
- ✅画像選択しているのに、画像選択していないことになっている
- ✅削除リンク上に注意文※
- ✅削除リンク押した後の注意文