### PR TITLE
Add story event idea placement support

### DIFF
--- a/app/controllers/ai_generations_controller.rb
+++ b/app/controllers/ai_generations_controller.rb
@@ -135,6 +135,8 @@ class AiGenerationsController < ApplicationController
       StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
     when "StoryElement"
       StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    when "StoryEventIdea"
+      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find_by(id: id)
     end
   end
 
@@ -159,6 +161,8 @@ class AiGenerationsController < ApplicationController
       placeable
     when StoryEvent, StoryElement
       placeable.story
+    when StoryEventIdea
+      placeable.story_event.story
     end
   end
 

--- a/app/controllers/idea_placements_controller.rb
+++ b/app/controllers/idea_placements_controller.rb
@@ -6,7 +6,6 @@ class IdeaPlacementsController < ApplicationController
     idea = current_user.ideas.find(params[:idea_id])
     placeable = find_placeable!(params[:placeable_type], params[:placeable_id])
 
-    # ✅ 即移動：既存があれば更新（1アイデア=1移動先）
     placement = idea.idea_placement || idea.build_idea_placement
     placement.placeable = placeable
     placement.created_here = false
@@ -25,6 +24,8 @@ class IdeaPlacementsController < ApplicationController
       StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find(id)
     when "StoryElement"
       StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find(id)
+    when "StoryEventIdea"
+      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find(id)
     else
       raise ActiveRecord::RecordNotFound
     end
@@ -35,9 +36,15 @@ class IdeaPlacementsController < ApplicationController
     when Story
       story_path(placeable)
     when StoryEvent
-      story_story_event_path(placeable.story, placeable) # イベント詳細（メモ一覧）
+      story_story_event_path(placeable.story, placeable)
     when StoryElement
-      story_story_element_path(placeable.story, placeable) # キャラ詳細
+      story_story_element_path(placeable.story, placeable)
+    when StoryEventIdea
+      story_story_event_story_event_idea_path(
+        placeable.story_event.story,
+        placeable.story_event,
+        placeable
+      )
     else
       ideas_path
     end

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -7,7 +7,6 @@ class IdeasController < ApplicationController
   before_action :sync_search_story_context_from_idea, only: %i[show edit update]
 
   def index
-    # ✅ ホーム＝「どこにも移動していないアイデア」だけ表示
     @ideas = current_user.ideas
                          .where.missing(:idea_placement)
                          .order(created_at: :desc)
@@ -21,13 +20,16 @@ class IdeasController < ApplicationController
 
     @story_events = StoryEvent.where(story_id: story_ids).order(created_at: :desc)
     @story_elements = StoryElement.includes(:story).where(story_id: story_ids).to_a
+    @story_event_ideas = StoryEventIdea.includes(story_event: :story)
+                                       .joins(story_event: :story)
+                                       .where(stories: { user_id: current_user.id })
+                                       .order(created_at: :desc)
   end
 
   def new
     @idea = current_user.ideas.new
     @idea.build_idea_image if @idea.idea_image.nil?
 
-    # ストーリー/イベント/要素から来た new は placement を持たせる（created_here: true）
     if params[:placeable_type].present? && params[:placeable_id].present?
       @idea.build_idea_placement(
         placeable_type: params[:placeable_type],
@@ -47,7 +49,6 @@ class IdeasController < ApplicationController
     pt  = params.dig(:idea, :idea_placement_attributes, :placeable_type).presence
     pid = params.dig(:idea, :idea_placement_attributes, :placeable_id).presence
 
-    # ✅ ストーリー/イベント/要素からの作成だけ placement を確定させる
     if pt.present? && pid.present?
       placement = @idea.idea_placement || @idea.build_idea_placement
       placement.placeable_type = pt
@@ -102,6 +103,7 @@ class IdeasController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def destroy
     redirect_path =
       case @idea.idea_placement&.placeable
@@ -111,6 +113,12 @@ class IdeasController < ApplicationController
         story_story_event_path(@idea.idea_placement.placeable.story, @idea.idea_placement.placeable)
       when StoryElement
         story_story_element_path(@idea.idea_placement.placeable.story, @idea.idea_placement.placeable)
+      when StoryEventIdea
+        story_story_event_story_event_idea_path(
+          @idea.idea_placement.placeable.story_event.story,
+          @idea.idea_placement.placeable.story_event,
+          @idea.idea_placement.placeable
+        )
       else
         ideas_path
       end
@@ -118,10 +126,10 @@ class IdeasController < ApplicationController
     @idea.destroy!
     redirect_to redirect_path, notice: "アイデアを削除しました"
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 
-  # ✅ ideas/new で placeable が来ている場合、ヘッダー用の story context を入れる
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def sync_search_story_context_from_placeable
     pt = params[:placeable_type].to_s
@@ -133,15 +141,22 @@ class IdeasController < ApplicationController
       when "Story"
         current_user.stories.find_by(id: pid)
       when "StoryEvent"
-        StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: pid)&.story
+        StoryEvent.joins(:story)
+                  .where(stories: { user_id: current_user.id })
+                  .find_by(id: pid)&.story
       when "StoryElement"
-        StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: pid)&.story
+        StoryElement.joins(:story)
+                    .where(stories: { user_id: current_user.id })
+                    .find_by(id: pid)&.story
+      when "StoryEventIdea"
+        StoryEventIdea.joins(story_event: :story)
+                      .where(stories: { user_id: current_user.id })
+                      .find_by(id: pid)&.story_event&.story
       end
 
     return if story.blank?
 
     session[:search_story_id] = story.id
-    # 初回はON寄せ。すでにfalseなら尊重する
     session[:search_in_story] = true if session[:search_in_story].nil?
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -150,9 +165,7 @@ class IdeasController < ApplicationController
     @idea = current_user.ideas.find(params[:id])
   end
 
-  # ✅ アイデア詳細/編集は「ホームかストーリー配下か」で session を確定させる
-  # - ホームアイデア(placementなし): 絶対にチェックを出さないため session を消す
-  # - placementあり: そのストーリーIDを session に入れる（ON/OFFはユーザー操作を尊重）
+  # rubocop:disable Metrics/AbcSize
   def sync_search_story_context_from_idea
     placement = @idea.idea_placement
 
@@ -168,6 +181,8 @@ class IdeasController < ApplicationController
         placement.placeable
       when StoryEvent, StoryElement
         placement.placeable.story
+      when StoryEventIdea
+        placement.placeable.story_event.story
       end
 
     return if story.blank?
@@ -175,8 +190,8 @@ class IdeasController < ApplicationController
     session[:search_story_id] = story.id
     session[:search_in_story] = true if session[:search_in_story].nil?
   end
+  # rubocop:enable Metrics/AbcSize
 
-  # ✅ story_element_ids: [] を許可
   def idea_params
     params.require(:idea).permit(
       :title, :memo,
@@ -198,6 +213,7 @@ class IdeasController < ApplicationController
     return Story.find(params[:story_id]) if params[:story_id].present?
     return StoryEvent.find(params[:story_event_id]).story if params[:story_event_id].present?
     return StoryElement.find(params[:story_element_id]).story if params[:story_element_id].present?
+    return StoryEventIdea.find(params[:story_event_idea_id]).story_event.story if params[:story_event_idea_id].present?
 
     if params[:placeable_type].present? && params[:placeable_id].present?
       placeable = find_placeable_for_current_user(params[:placeable_type], params[:placeable_id])
@@ -243,6 +259,8 @@ class IdeasController < ApplicationController
       StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
     when "StoryElement"
       StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    when "StoryEventIdea"
+      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find_by(id: id)
     end
   end
 
@@ -252,6 +270,8 @@ class IdeasController < ApplicationController
       placeable
     when StoryEvent, StoryElement
       placeable.story
+    when StoryEventIdea
+      placeable.story_event.story
     end
   end
 end

--- a/app/controllers/story_event_ideas_controller.rb
+++ b/app/controllers/story_event_ideas_controller.rb
@@ -4,12 +4,35 @@ class StoryEventIdeasController < ApplicationController
   before_action :set_story_and_event
   before_action :set_story_event_idea, only: %i[show edit update destroy move_up move_down]
 
-  def show; end
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def show
+    ideas = current_user.ideas
+                        .joins(:idea_placement)
+                        .where(idea_placements: { placeable_type: "StoryEventIdea", placeable_id: @story_event_idea.id })
+                        .includes(:idea_placement)
+                        .distinct
+
+    @created_here_ideas = ideas.select do |idea|
+      placement = idea.idea_placement
+      placement.present? &&
+        placement.placeable_type == "StoryEventIdea" &&
+        placement.placeable_id == @story_event_idea.id &&
+        placement.created_here?
+    end
+
+    @moved_ideas = ideas.select do |idea|
+      placement = idea.idea_placement
+      placement.present? &&
+        placement.placeable_type == "StoryEventIdea" &&
+        placement.placeable_id == @story_event_idea.id &&
+        !placement.created_here?
+    end
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def new
     @story_event_idea = @story_event.story_event_ideas.new
 
-    # ✅ idea詳細から飛んできた場合に紐付けを初期セット（安全に）
     return if params[:idea_id].blank?
 
     idea = current_user.ideas.find_by(id: params[:idea_id])
@@ -81,7 +104,7 @@ class StoryEventIdeasController < ApplicationController
   def story_event_idea_params
     params.require(:story_event_idea).permit(
       :title, :memo, :image, :position,
-      :idea_id, # ✅ 追加（これがないと紐付けできない）
+      :idea_id,
       story_element_ids: []
     )
   end

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -15,6 +15,13 @@
     when StoryElement
       back_label = "要素詳細に戻る"
       back_path  = story_story_element_path(placement.placeable.story, placement.placeable)
+    when StoryEventIdea
+      back_label = "詳細メモ詳細に戻る"
+      back_path  = story_story_event_story_event_idea_path(
+        placement.placeable.story_event.story,
+        placement.placeable.story_event,
+        placement.placeable
+      )
     end
   end
 
@@ -75,16 +82,17 @@
 
 <% tab = params[:tab].presence || @tab %>
 
-<h3>このアイデアどこへ移動する？（まず3つから選ぶ）</h3>
+<h3>このアイデアどこへ移動する？（まず4つから選ぶ）</h3>
 
 <ul>
   <li><%= link_to "ストーリー詳細ページへ", idea_path(@idea, tab: "stories") %></li>
   <li><%= link_to "イベント詳細（メモ一覧）ページへ", idea_path(@idea, tab: "events") %></li>
+  <li><%= link_to "詳細メモ詳細ページへ", idea_path(@idea, tab: "event_ideas") %></li>
   <li><%= link_to "キャラ（要素）詳細ページへ", idea_path(@idea, tab: "elements") %></li>
 </ul>
 
 <% if tab.present? %>
-  <p><%= link_to "← 3択に戻る", idea_path(@idea) %></p>
+  <p><%= link_to "← 4択に戻る", idea_path(@idea) %></p>
 <% end %>
 
 <% if tab == "elements" %>
@@ -132,6 +140,34 @@
                       params: { placeable_type: "Story", placeable_id: story.id } %>
         |
         <%= link_to "詳細を見る", story_path(story) %>
+      </li>
+    <% end %>
+  </ul>
+
+<% elsif tab == "event_ideas" %>
+  <hr>
+  <h3>詳細メモを選ぶ</h3>
+
+  <ul>
+    <% (@story_event_ideas || []).each do |event_idea| %>
+      <li>
+        <strong>
+          <%= event_idea.story_event&.story&.title %> /
+          <%= event_idea.story_event&.title %> /
+          <%= event_idea.title %>
+        </strong>
+        |
+        <%= button_to "ここへ移動",
+                      idea_idea_placement_path(@idea),
+                      method: :post,
+                      params: { placeable_type: "StoryEventIdea", placeable_id: event_idea.id } %>
+        |
+        <%= link_to "詳細を見る",
+                    story_story_event_story_event_idea_path(
+                      event_idea.story_event.story,
+                      event_idea.story_event,
+                      event_idea
+                    ) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/story_event_ideas/show.html.erb
+++ b/app/views/story_event_ideas/show.html.erb
@@ -30,3 +30,46 @@
 <p>
   <%= link_to "編集", edit_story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea) %>
 </p>
+
+<hr>
+
+<h3>新規アイデア</h3>
+
+<p>
+  <%= link_to "新規作成",
+              new_idea_path(
+                return_to: request.fullpath,
+                placeable_type: "StoryEventIdea",
+                placeable_id: @story_event_idea.id
+              ) %> |
+  <%= link_to "AI作成",
+              random_words_pick_path(
+                return_to: request.fullpath,
+                placeable_type: "StoryEventIdea",
+                placeable_id: @story_event_idea.id
+              ) %>
+</p>
+
+<% if @created_here_ideas.present? %>
+  <ul>
+    <% @created_here_ideas.each do |idea| %>
+      <li><%= link_to idea.title, idea_path(idea) %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>まだありません</p>
+<% end %>
+
+<hr>
+
+<h3>ここに移動したアイデア</h3>
+
+<% if @moved_ideas.present? %>
+  <ul>
+    <% @moved_ideas.each do |idea| %>
+      <li><%= link_to idea.title, idea_path(idea) %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>まだありません</p>
+<% end %>


### PR DESCRIPTION
✅新規アイデア欄とここに移動したアイデア欄の作成

✅アイデアの新規作成機能

✅要素指定できない

✅アイデアの戻り先がホームになっている

🔰⬇️Ⓜ️🅰編集AI作成機能

✅ホームに保存されるので、修正

🔰⬇️Ⓜ️🅰編集アイデア編集

✅全部のアイデアの移動する項目を増やしたり、表示を拡張

アイデア移動テスト

✅まず、全ページから、アイデアとアイデアを送る（問題なし）

次に、詳細メモから新規作成とAI作成して、移動できるか

✅ストーリー

✅イベント

✅詳細

✅要素