### PR TITLE
Improve story element UI and display labels

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -239,8 +239,9 @@ class IdeasController < ApplicationController
     elements.map do |element|
       marker = element.marker.presence
       name   = element.name.presence
-      kind   = element.kind.presence
-      label  = [marker, name, kind].compact.join(" ")
+      kind   = { "character" => "キャラクター", "item" => "アイテム", "setting" => "設定" }[element.kind] || element.kind
+      main_label = [marker, name].compact.join(" ")
+      label  = kind.present? ? "#{main_label}（#{kind}）" : main_label
       value  = element.id.to_s
       [label, value]
     end

--- a/app/controllers/story_elements_controller.rb
+++ b/app/controllers/story_elements_controller.rb
@@ -26,12 +26,17 @@ class StoryElementsController < ApplicationController
 
   def new
     @story_element = @story.story_elements.new
+    @story_element.build_story_element_image if @story_element.story_element_image.nil?
   end
 
-  def edit; end
+  def edit
+    @story_element.build_story_element_image if @story_element.story_element_image.nil?
+  end
 
   def create
     @story_element = @story.story_elements.new(story_element_params)
+    @story_element.build_story_element_image if @story_element.story_element_image.nil?
+
     if @story_element.save
       redirect_to story_story_elements_path(@story), notice: t(".success")
     else
@@ -43,6 +48,7 @@ class StoryElementsController < ApplicationController
     if @story_element.update(story_element_params)
       redirect_to story_story_elements_path(@story), notice: t(".success")
     else
+      @story_element.build_story_element_image if @story_element.story_element_image.nil?
       render :edit, status: :unprocessable_entity
     end
   end
@@ -69,6 +75,9 @@ class StoryElementsController < ApplicationController
   end
 
   def story_element_params
-    params.require(:story_element).permit(:kind, :name, :memo, :marker)
+    params.require(:story_element).permit(
+      :kind, :name, :memo, :marker,
+      story_element_image_attributes: %i[id image image_cache remove_image]
+    )
   end
 end

--- a/app/helpers/story_elements_helper.rb
+++ b/app/helpers/story_elements_helper.rb
@@ -4,14 +4,19 @@ module StoryElementsHelper
     name   = element.name.to_s
     kind   = story_element_kind_label(element)
 
-    [marker, name, kind].compact.join(" ")
+    main_label = [marker, name].compact.join(" ")
+    return main_label if kind.blank?
+
+    "#{main_label}（#{kind}）"
   end
 
   def story_element_kind_label(element)
-    # enum を使ってる場合は kind_i18n が生えることが多い
     return element.kind_i18n if element.respond_to?(:kind_i18n) && element.kind_i18n.present?
 
-    # それ以外は kind をそのまま出す（nil/空なら出さない）
-    element.kind.to_s.presence
+    {
+      "character" => "キャラクター",
+      "item" => "アイテム",
+      "setting" => "設定"
+    }[element.kind.to_s] || element.kind.to_s.presence
   end
 end

--- a/app/models/story_element.rb
+++ b/app/models/story_element.rb
@@ -1,15 +1,22 @@
 class StoryElement < ApplicationRecord
   belongs_to :story
 
+  has_one :story_element_image, dependent: :destroy
+
   has_many :story_event_elements, dependent: :destroy
   has_many :story_events, through: :story_event_elements
 
   has_many :story_event_idea_elements, dependent: :destroy
   has_many :story_event_ideas, through: :story_event_idea_elements
 
+  has_many :idea_placement_elements, dependent: :destroy
+  has_many :linked_idea_placements, through: :idea_placement_elements, source: :idea_placement
+
   # ✅ 追加（このキャラ/要素に「移動してきたアイデア」をぶら下げる）
   has_many :idea_placements, as: :placeable, dependent: :destroy
   has_many :placed_ideas, through: :idea_placements, source: :idea
+
+  accepts_nested_attributes_for :story_element_image, allow_destroy: true
 
   enum :kind, { character: 0, item: 1, setting: 2 }
 

--- a/app/models/story_element_image.rb
+++ b/app/models/story_element_image.rb
@@ -1,0 +1,5 @@
+class StoryElementImage < ApplicationRecord
+  belongs_to :story_element
+
+  mount_uploader :image, IdeaImageUploader
+end

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -52,7 +52,9 @@
     <strong>登場要素：</strong>
     <ul style="margin: 8px 0;">
       <% elements.each do |el| %>
-        <% label = [el.marker.presence, el.name.presence, el.kind.presence].compact.join(" ") %>
+        <% kind_label = { "character" => "キャラクター", "item" => "アイテム", "setting" => "設定" }[el.kind] || el.kind %>
+        <% main_label = [el.marker.presence, el.name.presence].compact.join(" ") %>
+        <% label = kind_label.present? ? "#{main_label}（#{kind_label}）" : main_label %>
         <% next if label.blank? %>
         <li><%= label %></li>
       <% end %>

--- a/app/views/story_elements/_form.html.erb
+++ b/app/views/story_elements/_form.html.erb
@@ -1,4 +1,5 @@
-<%= form_with model: [@story, @story_element] do |f| %>
+<%= form_with model: [@story, @story_element],
+              data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
   <% if @story_element.errors.any? %>
     <ul>
       <% @story_element.errors.full_messages.each do |msg| %>
@@ -7,25 +8,68 @@
     </ul>
   <% end %>
 
-  <div>
-    <%= f.label :kind %>
-    <%= f.select :kind, StoryElement.kinds.keys.map { |k| [k, k] }, include_blank: true %>
+  <div style="margin-bottom: 20px;">
+    <%= f.label :kind, "分類", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.select :kind,
+                 [["キャラクター", "character"], ["アイテム", "item"], ["設定", "setting"]],
+                 { include_blank: true },
+                 { style: "width: 100%; max-width: 220px; box-sizing: border-box;" } %>
   </div>
 
-  <div>
-    <%= f.label :marker %>
-    <%= f.text_field :marker, placeholder: "例：🃏 🗡️ 🔰 🤴🏻" %>
+  <div style="margin-bottom: 20px;" data-controller="character-counter">
+    <%= f.label :marker, "マーカー（4文字を超えた分は消えます）", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_field :marker,
+                     maxlength: 4,
+                     data: {
+                       "character-counter-target": "input",
+                       action: "input->character-counter#updateCount"
+                     },
+                     placeholder: "例：🃏 🗡️ 🔰 🤴🏻",
+                     style: "width: 100%; max-width: 220px; box-sizing: border-box;" %>
+    <div
+      data-character-counter-target="output"
+      data-max-length="4"
+      style="margin-top: 6px; font-size: 14px; color: #666;"
+    ></div>
   </div>
 
-  <div>
-    <%= f.label :name %>
-    <%= f.text_field :name %>
+  <div style="margin-bottom: 30px;" data-controller="character-counter">
+    <%= f.label :name, "名前（40文字を超えた分は消えます）", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_field :name,
+                     maxlength: 40,
+                     data: {
+                       "character-counter-target": "input",
+                       action: "input->character-counter#updateCount"
+                     },
+                     style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
+    <div
+      data-character-counter-target="output"
+      data-max-length="40"
+      style="margin-top: 6px; font-size: 14px; color: #666;"
+    ></div>
   </div>
 
-  <div>
-    <%= f.label :memo %>
-    <%= f.text_area :memo %>
+  <div style="margin-bottom: 30px;">
+    <%= f.label :memo, "メモ", style: "font-size: 24px; font-weight: bold;" %><br>
+    <%= f.text_area :memo, rows: 28, style: "width: 100%; max-width: 100%; box-sizing: border-box;" %>
   </div>
 
-  <%= f.submit %>
+  <%= f.fields_for :story_element_image do |imgf| %>
+    <%= imgf.hidden_field :id if imgf.object&.persisted? %>
+
+    <div style="margin-bottom: 30px;">
+      <%= imgf.label :image, "画像（任意）", style: "font-size: 24px; font-weight: bold;" %><br>
+      <%= imgf.file_field :image %>
+
+      <% if @story_element.story_element_image&.image? %>
+        <div style="margin-top: 8px;">
+          <%= image_tag @story_element.story_element_image.image.url, style: "max-width: 320px; height: auto;" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div style="margin-top: 24px;">
+    <%= f.submit "要素を保存する" %>
+  </div>
 <% end %>

--- a/app/views/story_elements/edit.html.erb
+++ b/app/views/story_elements/edit.html.erb
@@ -1,12 +1,16 @@
+<%= link_to "戻る", story_story_element_path(@story, @story_element) %>
+
 <h1>要素編集</h1>
 
 <%= render "form" %>
 
-<hr>
+<p style="color: red; font-weight: bold; margin-top: 24px; margin-bottom: 8px;">
+  削除すると、この要素内のアイデアは消えます。<br>
+  また、このストーリー内でこの要素を選択しているアイデア、イベントなどからも外れます。
+</p>
 
-<%= button_to "削除",
-      story_story_element_path(@story, @story_element),
-      method: :delete,
-      data: { turbo_confirm: "削除しますか？" } %>
-
-<%= link_to "戻る", story_story_element_path(@story, @story_element) %>
+<p>
+  <%= link_to "削除",
+        story_story_element_path(@story, @story_element),
+        data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？要素内アイデアと要素選択したアイデアなどからも外れます" } %>
+</p>

--- a/app/views/story_elements/index.html.erb
+++ b/app/views/story_elements/index.html.erb
@@ -2,15 +2,26 @@
 
 <h1>要素一覧</h1>
 
-<%= link_to "＋要素追加", new_story_story_element_path(@story) %>
+<%= link_to "要素追加", new_story_story_element_path(@story) %>
 
-<ul>
-  <% @story_elements.each do |e| %>
-    <li>
-      <%= link_to "#{e.marker.present? ? "#{e.marker} " : ""}#{e.kind} / #{e.name}",
-                  story_story_element_path(@story, e) %>
-      <%= link_to "編集", edit_story_story_element_path(@story, e) %>
-      <%# 削除は編集画面だけにしたいので、ここでは出さない %>
-    </li>
-  <% end %>
-</ul>
+<% grouped_elements = @story_elements.group_by(&:kind) %>
+
+<% [
+  ["character", "キャラクター"],
+  ["item", "アイテム"],
+  ["setting", "設定"]
+].each do |kind, title| %>
+  <% next if grouped_elements[kind].blank? %>
+
+  <h2><%= title %></h2>
+
+  <ul>
+    <% grouped_elements[kind].each do |e| %>
+      <li>
+        <%= link_to "#{e.marker.present? ? "#{e.marker}　" : ""}#{e.name}",
+                    story_story_element_path(@story, e) %>
+        <%# 削除は編集画面だけにしたいので、ここでは出さない %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/story_elements/new.html.erb
+++ b/app/views/story_elements/new.html.erb
@@ -1,3 +1,3 @@
+<%= link_to "戻る", story_story_elements_path(@story) %>
 <h1>要素追加</h1>
 <%= render "form" %>
-<%= link_to "戻る", story_story_elements_path(@story) %>

--- a/app/views/story_elements/show.html.erb
+++ b/app/views/story_elements/show.html.erb
@@ -2,9 +2,15 @@
 
 <h1>要素詳細</h1>
 
-<p><strong>種別：</strong><%= @story_element.kind %></p>
+<p style="font-size: 32px; font-weight: bold; margin: 0 0 16px 0;"><strong>名前：</strong><%= @story_element.name %></p>
+<p><strong>種別：</strong><%= { "character" => "キャラクター", "item" => "アイテム", "setting" => "設定" }[@story_element.kind] || @story_element.kind %></p>
 <p><strong>マーカー：</strong><%= @story_element.marker.presence || "なし" %></p>
-<p><strong>名前：</strong><%= @story_element.name %></p>
+
+<% if @story_element.story_element_image&.image? %>
+  <div style="margin: 12px 0;">
+    <%= image_tag @story_element.story_element_image.image.url, style: "max-width: 100%; height: auto;" %>
+  </div>
+<% end %>
 
 <h2>メモ</h2>
 

--- a/db/migrate/20260320040355_create_story_element_images.rb
+++ b/db/migrate/20260320040355_create_story_element_images.rb
@@ -1,0 +1,10 @@
+class CreateStoryElementImages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :story_element_images do |t|
+      t.references :story_element, null: false, foreign_key: true
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_18_044828) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_20_040355) do
   create_table "idea_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "idea_id", null: false
     t.string "image"
@@ -76,6 +76,14 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_044828) do
     t.datetime "updated_at", null: false
     t.integer "position"
     t.index ["user_id"], name: "index_stories_on_user_id"
+  end
+
+  create_table "story_element_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "story_element_id", null: false
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["story_element_id"], name: "index_story_element_images_on_story_element_id"
   end
 
   create_table "story_elements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -169,6 +177,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_18_044828) do
   add_foreign_key "ideas", "users"
   add_foreign_key "inquiries", "users"
   add_foreign_key "stories", "users"
+  add_foreign_key "story_element_images", "story_elements"
   add_foreign_key "story_elements", "stories"
   add_foreign_key "story_event_elements", "story_elements"
   add_foreign_key "story_event_elements", "story_events"


### PR DESCRIPTION
- 要素新規作成
- ✅キャラ、アイテムなどが英語表記なので日本語に
- （✅要素、✅要素一覧、✅要素詳細、
- アイデア　✅新規、
- ✅詳細、
- ✅編集（ストーリー、イベント、詳細メモ、要素）
- ✅イベント新規、
- ✅詳細、
- ✅編集、（）
- ✅詳細メモ新規、
- ✅しょうさい、
- ✅編集）
- ✅追加欄の拡張
- ✅メモの下に画像機能を作成する。一覧には表示しない
- ✅要素作成のname、マーカーに文字数制限、カウント
- ✅タイトルで、エンター押すとエラー出るor保存されるので修正
- 🔰⬇️Ⓜ️🅰要素詳細
- 要素編集
- ✅40文字を超えた文は消える
- ✅削除リンク上に注意文※
- ✅削除リンク押した後の注意文
- 全ページの要素選択や表示の確認（表記の順番　見やすく）

🧩🟣 サトシ （キャラクター）

出てくる場所

✅イベント追加

✅イベント詳細

✅イベント編集

✅アイデア新規

✅アイデア詳細

✅アイデア編集

✅詳細メモ追加

✅詳細メモ詳細

✅詳細メモ編集

✅アイデア新規

✅アイデア詳細

✅アイデア編集

✅要素内のアイデア作成

✅アイデア編集

要素一覧

✅要素一覧を、キャラクター、アイテムなどで分ける