### PR TITLE
Improve element display and text update timestamps

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -38,7 +38,7 @@ class IdeasController < ApplicationController
       )
     end
 
-    set_marker_options
+    set_available_story_elements
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
@@ -63,7 +63,7 @@ class IdeasController < ApplicationController
       redirect_to(safe_path(params[:return_to]) || ideas_path, notice: "アイデアを作成しました")
     else
       @idea.build_idea_image if @idea.idea_image.nil?
-      set_marker_options
+      set_available_story_elements
       render :new, status: :unprocessable_entity
     end
   end
@@ -73,9 +73,9 @@ class IdeasController < ApplicationController
     @idea.build_idea_image if @idea.idea_image.nil?
 
     if @idea.idea_placement.present?
-      set_marker_options
+      set_available_story_elements
     else
-      @marker_options = []
+      @available_story_elements = []
     end
   end
 
@@ -94,9 +94,9 @@ class IdeasController < ApplicationController
       @idea.build_idea_image if @idea.idea_image.nil?
 
       if @idea.idea_placement.present?
-        set_marker_options
+        set_available_story_elements
       else
-        @marker_options = []
+        @available_story_elements = []
       end
 
       render :edit, status: :unprocessable_entity
@@ -203,9 +203,9 @@ class IdeasController < ApplicationController
     )
   end
 
-  def set_marker_options
+  def set_available_story_elements
     story = resolve_story_for_marker
-    @marker_options = marker_options_for(story)
+    @available_story_elements = available_story_elements_for(story)
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -230,21 +230,12 @@ class IdeasController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-  def marker_options_for(story)
+  def available_story_elements_for(story)
     return [] if story.nil?
 
     elements = story.story_elements
     elements = elements.order(:position) if elements.respond_to?(:klass) && elements.klass.column_names.include?("position")
-
-    elements.map do |element|
-      marker = element.marker.presence
-      name   = element.name.presence
-      kind   = { "character" => "キャラクター", "item" => "アイテム", "setting" => "設定" }[element.kind] || element.kind
-      main_label = [marker, name].compact.join(" ")
-      label  = kind.present? ? "#{main_label}（#{kind}）" : main_label
-      value  = element.id.to_s
-      [label, value]
-    end
+    elements
   end
 
   def safe_path(value)

--- a/app/controllers/story_elements_controller.rb
+++ b/app/controllers/story_elements_controller.rb
@@ -46,7 +46,7 @@ class StoryElementsController < ApplicationController
 
   def update
     if @story_element.update(story_element_params)
-      redirect_to story_story_elements_path(@story), notice: t(".success")
+      redirect_to story_story_element_path(@story, @story_element), notice: t(".success")
     else
       @story_element.build_story_element_image if @story_element.story_element_image.nil?
       render :edit, status: :unprocessable_entity

--- a/app/controllers/story_event_ideas_controller.rb
+++ b/app/controllers/story_event_ideas_controller.rb
@@ -11,6 +11,7 @@ class StoryEventIdeasController < ApplicationController
                         .where(idea_placements: { placeable_type: "StoryEventIdea", placeable_id: @story_event_idea.id })
                         .includes(:idea_placement)
                         .distinct
+                        .order(created_at: :desc)
 
     @created_here_ideas = ideas.select do |idea|
       placement = idea.idea_placement

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,26 @@
 module ApplicationHelper
   def story_element_label(element)
-    [element.marker.presence, element.name].compact.join(" ")
+    marker = element.marker.presence
+    name   = element.name.to_s
+    kind   = story_element_kind_label(element)
+
+    main_label = [marker, name].compact.join("　")
+    return main_label if kind.blank?
+
+    "#{main_label}（#{kind}）"
+  end
+
+  def story_element_short_label(element)
+    [element.marker.presence, element.name.to_s].compact.join("　")
+  end
+
+  def story_element_kind_label(element)
+    return element.kind_i18n if element.respond_to?(:kind_i18n) && element.kind_i18n.present?
+
+    {
+      "character" => "キャラクター",
+      "item" => "アイテム",
+      "setting" => "設定"
+    }[element.kind.to_s] || element.kind.to_s.presence
   end
 end

--- a/app/helpers/story_elements_helper.rb
+++ b/app/helpers/story_elements_helper.rb
@@ -1,22 +1,2 @@
 module StoryElementsHelper
-  def story_element_label(element)
-    marker = element.marker.presence
-    name   = element.name.to_s
-    kind   = story_element_kind_label(element)
-
-    main_label = [marker, name].compact.join(" ")
-    return main_label if kind.blank?
-
-    "#{main_label}（#{kind}）"
-  end
-
-  def story_element_kind_label(element)
-    return element.kind_i18n if element.respond_to?(:kind_i18n) && element.kind_i18n.present?
-
-    {
-      "character" => "キャラクター",
-      "item" => "アイテム",
-      "setting" => "設定"
-    }[element.kind.to_s] || element.kind.to_s.presence
-  end
 end

--- a/app/javascript/controllers/element_selector_controller.js
+++ b/app/javascript/controllers/element_selector_controller.js
@@ -1,0 +1,108 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "selectedArea",
+    "group",
+    "checkbox",
+    "summary",
+    "emptyMessage"
+  ]
+
+  connect() {
+    this.refresh()
+  }
+
+  toggle(event) {
+    const button = event.currentTarget
+    const kind = button.dataset.kind
+    const group = this.groupTargets.find((element) => element.dataset.kind === kind)
+    if (!group) return
+
+    const isHidden = group.hasAttribute("hidden")
+
+    if (isHidden) {
+      group.removeAttribute("hidden")
+      button.textContent = `▼ ${button.dataset.label}`
+      button.setAttribute("aria-expanded", "true")
+    } else {
+      group.setAttribute("hidden", true)
+      button.textContent = `▶ ${button.dataset.label}`
+      button.setAttribute("aria-expanded", "false")
+    }
+  }
+
+  refresh() {
+    const selectedByKind = {
+      character: [],
+      item: [],
+      setting: []
+    }
+
+    this.checkboxTargets.forEach((checkbox) => {
+      if (!checkbox.checked) return
+
+      selectedByKind[checkbox.dataset.kind] ||= []
+      selectedByKind[checkbox.dataset.kind].push({
+        id: checkbox.value,
+        label: checkbox.dataset.label
+      })
+    })
+
+    this.summaryTargets.forEach((summary) => {
+      const kind = summary.dataset.kind
+      const items = selectedByKind[kind] || []
+
+      if (items.length === 0) {
+        summary.setAttribute("hidden", true)
+        summary.innerHTML = ""
+        return
+      }
+
+      summary.removeAttribute("hidden")
+      summary.innerHTML = `
+        <div style="font-weight: bold; margin-bottom: 8px;">
+          ${this.kindLabel(kind)}（${items.length}）
+        </div>
+        <div style="display: flex; flex-wrap: wrap; gap: 8px;">
+          ${items.map((item) => this.badgeHtml(item.label)).join("")}
+        </div>
+      `
+    })
+
+    if (this.hasEmptyMessageTarget) {
+      const hasAnySelected = Object.values(selectedByKind).some((items) => items.length > 0)
+
+      if (hasAnySelected) {
+        this.emptyMessageTarget.setAttribute("hidden", true)
+      } else {
+        this.emptyMessageTarget.removeAttribute("hidden")
+      }
+    }
+  }
+
+  badgeHtml(label) {
+    return `
+      <span style="display: inline-block; padding: 6px 10px; border: 1px solid #ccc; border-radius: 9999px;">
+        ${this.escapeHtml(label)}
+      </span>
+    `
+  }
+
+  kindLabel(kind) {
+    return {
+      character: "キャラクター",
+      item: "アイテム",
+      setting: "設定"
+    }[kind] || kind
+  }
+
+  escapeHtml(text) {
+    return String(text)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;")
+  }
+}

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -6,11 +6,22 @@ class Story < ApplicationRecord
   has_one :story_image, dependent: :destroy
   accepts_nested_attributes_for :story_image, update_only: true
 
-  # ✅ 追加（このストーリーに「移動してきたアイデア」をぶら下げる）
   has_many :idea_placements, as: :placeable, dependent: :destroy
   has_many :placed_ideas, through: :idea_placements, source: :idea
 
   TITLE_MAX_LENGTH = 40
 
   validates :title, presence: true, length: { maximum: TITLE_MAX_LENGTH }
+
+  before_save :set_text_updated_at, if: :should_update_text_updated_at?
+
+  private
+
+  def should_update_text_updated_at?
+    new_record? || will_save_change_to_title? || will_save_change_to_description?
+  end
+
+  def set_text_updated_at
+    self.text_updated_at = Time.current
+  end
 end

--- a/app/models/story_element.rb
+++ b/app/models/story_element.rb
@@ -12,7 +12,6 @@ class StoryElement < ApplicationRecord
   has_many :idea_placement_elements, dependent: :destroy
   has_many :linked_idea_placements, through: :idea_placement_elements, source: :idea_placement
 
-  # ✅ 追加（このキャラ/要素に「移動してきたアイデア」をぶら下げる）
   has_many :idea_placements, as: :placeable, dependent: :destroy
   has_many :placed_ideas, through: :idea_placements, source: :idea
 
@@ -22,4 +21,16 @@ class StoryElement < ApplicationRecord
 
   validates :kind, presence: true
   validates :name, presence: true
+
+  before_save :set_text_updated_at, if: :should_update_text_updated_at?
+
+  private
+
+  def should_update_text_updated_at?
+    new_record? || will_save_change_to_marker? || will_save_change_to_name? || will_save_change_to_memo?
+  end
+
+  def set_text_updated_at
+    self.text_updated_at = Time.current
+  end
 end

--- a/app/models/story_event.rb
+++ b/app/models/story_event.rb
@@ -9,10 +9,21 @@ class StoryEvent < ApplicationRecord
   has_one :story_event_image, dependent: :destroy
   accepts_nested_attributes_for :story_event_image, update_only: true
 
-  # ✅ 追加（このイベントに「移動してきたアイデア」をぶら下げる）
   has_many :idea_placements, as: :placeable, dependent: :destroy
   has_many :placed_ideas, through: :idea_placements, source: :idea
 
   validates :title, presence: true
   validates :position, presence: true, numericality: { only_integer: true }
+
+  before_save :set_text_updated_at, if: :should_update_text_updated_at?
+
+  private
+
+  def should_update_text_updated_at?
+    new_record? || will_save_change_to_title? || will_save_change_to_body?
+  end
+
+  def set_text_updated_at
+    self.text_updated_at = Time.current
+  end
 end

--- a/app/models/story_event_idea.rb
+++ b/app/models/story_event_idea.rb
@@ -1,6 +1,6 @@
 class StoryEventIdea < ApplicationRecord
   belongs_to :story_event
-  belongs_to :idea, optional: true # ✅ 追加
+  belongs_to :idea, optional: true
 
   has_many :story_event_idea_elements, dependent: :destroy
   has_many :story_elements, through: :story_event_idea_elements
@@ -8,4 +8,16 @@ class StoryEventIdea < ApplicationRecord
   validates :title, presence: true
 
   mount_uploader :image, IdeaImageUploader
+
+  before_save :set_text_updated_at, if: :should_update_text_updated_at?
+
+  private
+
+  def should_update_text_updated_at?
+    new_record? || will_save_change_to_title? || will_save_change_to_memo?
+  end
+
+  def set_text_updated_at
+    self.text_updated_at = Time.current
+  end
 end

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -1,4 +1,10 @@
-<%= form_with(model: idea, local: true, html: { multipart: true }, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" }) do |f| %>
+<%= form_with(model: idea,
+              local: true,
+              html: { multipart: true },
+              data: {
+                controller: "prevent-enter-submit element-selector",
+                action: "keydown->prevent-enter-submit#check change->element-selector#refresh"
+              }) do |f| %>
   <% if idea.errors.any? %>
     <div class="alert alert-danger">
       <ul class="mb-0">
@@ -46,7 +52,7 @@
   <% end %>
 
   <%# ✅ ストーリー文脈がある時だけ表示 %>
-  <% if idea.idea_placement.present? || @marker_options.present? || params[:placeable_type].present? %>
+  <% if idea.idea_placement.present? || @available_story_elements.present? || params[:placeable_type].present? %>
     <%= f.fields_for :idea_placement do |pf| %>
       <%= pf.hidden_field :id if pf.object&.persisted? %>
 
@@ -54,32 +60,70 @@
       <%= pf.hidden_field :placeable_id,   value: (pf.object&.placeable_id   || params[:placeable_id]) %>
 
       <div style="margin-top: 16px;">
-        <div><strong>このアイデアの登場要素（複数選択OK）</strong></div>
+        <div style="font-size: 24px; font-weight: bold;">このアイデアの登場要素</div>
 
-        <% if @marker_options.present? %>
+        <% if @available_story_elements.present? %>
+          <% grouped_elements = @available_story_elements.group_by(&:kind) %>
+
           <%= hidden_field_tag "idea[idea_placement_attributes][story_element_ids][]", "" %>
 
-          <% selected_ids =
-              if pf.object&.story_elements.present?
-                pf.object.story_elements.pluck(:id).map(&:to_s)
-              else
-                []
-              end
-          %>
-
-          <% @marker_options.each_with_index do |(label, value), i| %>
-            <div>
-              <label for="idea_marker_<%= i %>">
-                <%= check_box_tag(
-                      "idea[idea_placement_attributes][story_element_ids][]",
-                      value,
-                      selected_ids.include?(value.to_s),
-                      id: "idea_marker_#{i}"
-                    ) %>
-                <%= label %>
-              </label>
+          <div style="margin-top: 12px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+            <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px;">
+              選択中の要素
             </div>
-          <% end %>
+
+            <p data-element-selector-target="emptyMessage" style="margin: 0;">
+              まだ選択されていません
+            </p>
+
+            <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px;"></div>
+            <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px;"></div>
+            <div data-element-selector-target="summary" data-kind="setting" hidden></div>
+          </div>
+
+          <div style="margin-top: 16px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+            <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px;">
+              要素を選択する
+            </div>
+
+            <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+              <% elements = grouped_elements[kind] || [] %>
+              <% next if elements.blank? %>
+
+              <div style="margin-bottom: 16px;">
+                <button type="button"
+                        data-action="click->element-selector#toggle"
+                        data-kind="<%= kind %>"
+                        data-label="<%= "#{kind_label}（#{elements.size}）" %>"
+                        aria-expanded="true"
+                        style="width: 100%; text-align: left; background: #f8f9fa; border: 1px solid #ccc; border-radius: 6px; padding: 10px 12px; font-weight: bold;">
+                  ▼ <%= kind_label %>（<%= elements.size %>）
+                </button>
+
+                <div data-element-selector-target="group"
+                     data-kind="<%= kind %>"
+                     style="padding: 12px 8px 0 8px;">
+                  <%= pf.collection_check_boxes :story_element_ids, elements, :id, ->(el) { story_element_short_label(el) } do |b| %>
+                    <% element = b.object %>
+                    <div style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px;">
+                      <% checkbox_id = "#{pf.object_name}_story_element_ids_#{element.id}" %>
+
+                      <%= b.check_box id: checkbox_id,
+                            data: {
+                              "element-selector-target": "checkbox",
+                              kind: element.kind,
+                              label: story_element_short_label(element)
+                            } %>
+
+                      <label for="<%= checkbox_id %>" style="cursor: pointer; margin-bottom: 0;">
+                        <%= story_element_short_label(element) %>
+                      </label>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
         <% else %>
           <div>
             （このアイデアはストーリー文脈が特定できないため、要素一覧を表示できません）

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -35,11 +35,8 @@
 
 <h1><%= @idea.title %></h1>
 
-<%# ✅ 複数マーカー表示（選択された story_elements をそのまま出す） %>
 <% if placement.present? && placement.story_elements.present? %>
   <% elements = placement.story_elements.to_a %>
-
-  <%# 並び順：できれば kind → name → id（安定） %>
   <% elements =
       if elements.first.respond_to?(:kind) && elements.first.respond_to?(:name)
         elements.sort_by { |e| [e.kind.to_s, e.name.to_s, e.id.to_i] }
@@ -47,18 +44,34 @@
         elements.sort_by { |e| e.id.to_i }
       end
   %>
+  <% grouped_elements = elements.group_by(&:kind) %>
 
   <div style="margin: 12px 0;">
     <strong>登場要素：</strong>
-    <ul style="margin: 8px 0;">
-      <% elements.each do |el| %>
-        <% kind_label = { "character" => "キャラクター", "item" => "アイテム", "setting" => "設定" }[el.kind] || el.kind %>
-        <% main_label = [el.marker.presence, el.name.presence].compact.join(" ") %>
-        <% label = kind_label.present? ? "#{main_label}（#{kind_label}）" : main_label %>
-        <% next if label.blank? %>
-        <li><%= label %></li>
+
+    <div style="margin-top: 12px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+      <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+        <% kind_elements = grouped_elements[kind] || [] %>
+        <% next if kind_elements.blank? %>
+
+        <details style="margin-bottom: 16px;">
+          <summary style="cursor: pointer; background: #f8f9fa; border: 1px solid #ccc; border-radius: 6px; padding: 10px 12px; font-weight: bold;">
+            <%= kind_label %>（<%= kind_elements.size %>）
+          </summary>
+
+          <div style="padding: 12px 8px 0 8px;">
+            <% kind_elements.each do |el| %>
+              <% label = story_element_short_label(el) %>
+              <% next if label.blank? %>
+
+              <div style="margin-bottom: 8px;">
+                <%= label %>
+              </div>
+            <% end %>
+          </div>
+        </details>
       <% end %>
-    </ul>
+    </div>
   </div>
 <% end %>
 
@@ -111,7 +124,7 @@
 
     <ul>
       <% grouped[kind].sort_by { |e| [e.story&.title.to_s, e.name.to_s] }.each do |el| %>
-        <% name_with_marker = [el.marker.presence, el.name].compact.join(" ") %>
+        <% name_with_marker = [el.marker.presence, el.name].compact.join("　") %>
 
         <li>
           <strong><%= name_with_marker %></strong>（<%= el.story&.title %>）

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -19,6 +19,12 @@
 
 <p>
   <%= link_to "ストーリー編集", edit_story_path(@story) %>
+  <span style="display: inline-block; margin-left: 24px;">
+    作成日: <%= l @story.created_at.in_time_zone("Tokyo"), format: :short %>
+  </span>
+  <span style="display: inline-block; margin-left: 24px;">
+    更新日（文字修正のみ）: <%= l (@story.text_updated_at || @story.created_at).in_time_zone("Tokyo"), format: :short %>
+  </span>
 </p>
 
 <hr>

--- a/app/views/story_elements/show.html.erb
+++ b/app/views/story_elements/show.html.erb
@@ -22,6 +22,12 @@
 
 <p>
   <%= link_to "編集", edit_story_story_element_path(@story, @story_element) %>
+  <span style="display: inline-block; margin-left: 24px;">
+    作成日: <%= l @story_element.created_at.in_time_zone("Tokyo"), format: :short %>
+  </span>
+  <span style="display: inline-block; margin-left: 24px;">
+    更新日（文字修正のみ）: <%= l (@story_element.text_updated_at || @story_element.created_at).in_time_zone("Tokyo"), format: :short %>
+  </span>
 </p>
 
 <hr>

--- a/app/views/story_event_ideas/_form.html.erb
+++ b/app/views/story_event_ideas/_form.html.erb
@@ -1,4 +1,8 @@
-<%= form_with model: [@story, @story_event, @story_event_idea], data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
+<%= form_with model: [@story, @story_event, @story_event_idea],
+              data: {
+                controller: "prevent-enter-submit element-selector",
+                action: "keydown->prevent-enter-submit#check change->element-selector#refresh"
+              } do |f| %>
   <% if @story_event_idea.errors.any? %>
     <ul>
       <% @story_event_idea.errors.full_messages.each do |msg| %>
@@ -43,12 +47,62 @@
     <div style="font-size: 24px; font-weight: bold;">このメモの登場要素</div>
 
     <% if @story.story_elements.any? %>
-      <div style="margin-top: 12px;">
-        <%= f.collection_check_boxes :story_element_ids, @story.story_elements, :id,
-                                     ->(el) { story_element_label(el) } do |b| %>
-          <div>
-            <%= b.check_box %>
-            <%= b.label %>
+      <% grouped_elements = @story.story_elements.group_by(&:kind) %>
+
+      <div style="margin-top: 12px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px;">
+          選択中の要素
+        </div>
+
+        <p data-element-selector-target="emptyMessage" style="margin: 0;">
+          まだ選択されていません
+        </p>
+
+        <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px;"></div>
+        <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px;"></div>
+        <div data-element-selector-target="summary" data-kind="setting" hidden></div>
+      </div>
+
+      <div style="margin-top: 16px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px;">
+          要素を選択する
+        </div>
+
+        <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+          <% elements = grouped_elements[kind] || [] %>
+          <% next if elements.blank? %>
+
+          <div style="margin-bottom: 16px;">
+            <button type="button"
+                    data-action="click->element-selector#toggle"
+                    data-kind="<%= kind %>"
+                    data-label="<%= "#{kind_label}（#{elements.size}）" %>"
+                    aria-expanded="true"
+                    style="width: 100%; text-align: left; background: #f8f9fa; border: 1px solid #ccc; border-radius: 6px; padding: 10px 12px; font-weight: bold;">
+              ▼ <%= kind_label %>（<%= elements.size %>）
+            </button>
+
+            <div data-element-selector-target="group"
+                 data-kind="<%= kind %>"
+                 style="padding: 12px 8px 0 8px;">
+              <%= f.collection_check_boxes :story_element_ids, elements, :id, ->(el) { story_element_short_label(el) } do |b| %>
+                <% element = b.object %>
+                <div style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px;">
+                  <% checkbox_id = "#{f.object_name}_story_element_ids_#{element.id}" %>
+
+                  <%= b.check_box id: checkbox_id,
+                        data: {
+                          "element-selector-target": "checkbox",
+                          kind: element.kind,
+                          label: story_element_short_label(element)
+                        } %>
+
+                  <label for="<%= checkbox_id %>" style="cursor: pointer; margin-bottom: 0;">
+                    <%= story_element_short_label(element) %>
+                  </label>
+                </div>
+              <% end %>
+            </div>
           </div>
         <% end %>
       </div>

--- a/app/views/story_event_ideas/show.html.erb
+++ b/app/views/story_event_ideas/show.html.erb
@@ -6,11 +6,28 @@
 
 <h4>詳細メモの登場要素</h4>
 <% if @story_event_idea.story_elements.any? %>
-  <ul>
-    <% @story_event_idea.story_elements.each do |el| %>
-      <li><%= story_element_label(el) %></li>
+  <% grouped_elements = @story_event_idea.story_elements.group_by(&:kind) %>
+
+  <div style="margin-top: 12px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+    <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+      <% elements = grouped_elements[kind] || [] %>
+      <% next if elements.blank? %>
+
+      <details style="margin-bottom: 16px;">
+        <summary style="cursor: pointer; background: #f8f9fa; border: 1px solid #ccc; border-radius: 6px; padding: 10px 12px; font-weight: bold;">
+          <%= kind_label %>（<%= elements.size %>）
+        </summary>
+
+        <div style="padding: 12px 8px 0 8px;">
+          <% elements.each do |el| %>
+            <div style="margin-bottom: 8px;">
+              <%= story_element_short_label(el) %>
+            </div>
+          <% end %>
+        </div>
+      </details>
     <% end %>
-  </ul>
+  </div>
 <% else %>
   <p>未設定</p>
 <% end %>
@@ -29,6 +46,12 @@
 
 <p>
   <%= link_to "編集", edit_story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea) %>
+  <span style="display: inline-block; margin-left: 24px;">
+    作成日: <%= l @story_event_idea.created_at.in_time_zone("Tokyo"), format: :short %>
+  </span>
+  <span style="display: inline-block; margin-left: 24px;">
+    更新日（文字修正のみ）: <%= l (@story_event_idea.text_updated_at || @story_event_idea.created_at).in_time_zone("Tokyo"), format: :short %>
+  </span>
 </p>
 
 <hr>

--- a/app/views/story_events/_form.html.erb
+++ b/app/views/story_events/_form.html.erb
@@ -1,4 +1,9 @@
-<%= form_with model: [@story, @story_event], html: { multipart: true }, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
+<%= form_with model: [@story, @story_event],
+              html: { multipart: true },
+              data: {
+                controller: "prevent-enter-submit element-selector",
+                action: "keydown->prevent-enter-submit#check change->element-selector#refresh"
+              } do |f| %>
   <% if @story_event.errors.any? %>
     <ul>
       <% @story_event.errors.full_messages.each do |msg| %>
@@ -47,12 +52,62 @@
     <%= f.label :story_element_ids, "登場要素", style: "font-size: 24px; font-weight: bold;" %><br>
 
     <% if @story.story_elements.any? %>
-      <div style="margin-top: 12px;">
-        <%= f.collection_check_boxes :story_element_ids, @story.story_elements, :id,
-                                     ->(el) { story_element_label(el) } do |b| %>
-          <div>
-            <%= b.check_box %>
-            <%= b.label %>
+      <% grouped_elements = @story.story_elements.group_by(&:kind) %>
+
+      <div style="margin-top: 12px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px;">
+          選択中の要素
+        </div>
+
+        <p data-element-selector-target="emptyMessage" style="margin: 0;">
+          まだ選択されていません
+        </p>
+
+        <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px;"></div>
+        <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px;"></div>
+        <div data-element-selector-target="summary" data-kind="setting" hidden></div>
+      </div>
+
+      <div style="margin-top: 16px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px;">
+          要素を選択する
+        </div>
+
+        <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+          <% elements = grouped_elements[kind] || [] %>
+          <% next if elements.blank? %>
+
+          <div style="margin-bottom: 16px;">
+            <button type="button"
+                    data-action="click->element-selector#toggle"
+                    data-kind="<%= kind %>"
+                    data-label="<%= "#{kind_label}（#{elements.size}）" %>"
+                    aria-expanded="true"
+                    style="width: 100%; text-align: left; background: #f8f9fa; border: 1px solid #ccc; border-radius: 6px; padding: 10px 12px; font-weight: bold;">
+              ▼ <%= kind_label %>（<%= elements.size %>）
+            </button>
+
+            <div data-element-selector-target="group"
+                 data-kind="<%= kind %>"
+                 style="padding: 12px 8px 0 8px;">
+              <%= f.collection_check_boxes :story_element_ids, elements, :id, ->(el) { story_element_short_label(el) } do |b| %>
+                <% element = b.object %>
+                <div style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px;">
+                  <% checkbox_id = "#{f.object_name}_story_element_ids_#{element.id}" %>
+
+                  <%= b.check_box id: checkbox_id,
+                        data: {
+                          "element-selector-target": "checkbox",
+                          kind: element.kind,
+                          label: story_element_short_label(element)
+                        } %>
+
+                  <label for="<%= checkbox_id %>" style="cursor: pointer; margin-bottom: 0;">
+                    <%= story_element_short_label(element) %>
+                  </label>
+                </div>
+              <% end %>
+            </div>
           </div>
         <% end %>
       </div>
@@ -62,6 +117,6 @@
   </div>
 
   <div style="margin-top: 24px;">
-    <%= f.submit "イベントを更新する" %>
+    <%= f.submit "イベントを保存する" %>
   </div>
 <% end %>

--- a/app/views/story_events/show.html.erb
+++ b/app/views/story_events/show.html.erb
@@ -12,11 +12,28 @@
 
 <h4>イベントの登場要素</h4>
 <% if @story_event.story_elements.any? %>
-  <ul>
-    <% @story_event.story_elements.each do |el| %>
-      <li><%= story_element_label(el) %></li>
+  <% grouped_elements = @story_event.story_elements.group_by(&:kind) %>
+
+  <div style="margin-top: 12px; border: 1px solid #ddd; border-radius: 8px; padding: 16px;">
+    <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+      <% elements = grouped_elements[kind] || [] %>
+      <% next if elements.blank? %>
+
+      <details style="margin-bottom: 16px;">
+        <summary style="cursor: pointer; background: #f8f9fa; border: 1px solid #ccc; border-radius: 6px; padding: 10px 12px; font-weight: bold;">
+          <%= kind_label %>（<%= elements.size %>）
+        </summary>
+
+        <div style="padding: 12px 8px 0 8px;">
+          <% elements.each do |el| %>
+            <div style="margin-bottom: 8px;">
+              <%= story_element_short_label(el) %>
+            </div>
+          <% end %>
+        </div>
+      </details>
     <% end %>
-  </ul>
+  </div>
 <% else %>
   <p>未設定</p>
 <% end %>
@@ -28,6 +45,12 @@
 
 <p>
   <%= link_to "編集", edit_story_story_event_path(@story, @story_event) %>
+  <span style="display: inline-block; margin-left: 24px;">
+    作成日: <%= l @story_event.created_at.in_time_zone("Tokyo"), format: :short %>
+  </span>
+  <span style="display: inline-block; margin-left: 24px;">
+    更新日（文字修正のみ）: <%= l (@story_event.text_updated_at || @story_event.created_at).in_time_zone("Tokyo"), format: :short %>
+  </span>
 </p>
 
 <hr>

--- a/db/migrate/20260322045247_add_text_updated_at_to_stories_and_story_events_and_story_event_ideas_and_story_elements.rb
+++ b/db/migrate/20260322045247_add_text_updated_at_to_stories_and_story_events_and_story_event_ideas_and_story_elements.rb
@@ -1,0 +1,8 @@
+class AddTextUpdatedAtToStoriesAndStoryEventsAndStoryEventIdeasAndStoryElements < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stories, :text_updated_at, :datetime
+    add_column :story_events, :text_updated_at, :datetime
+    add_column :story_event_ideas, :text_updated_at, :datetime
+    add_column :story_elements, :text_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_20_040355) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_22_045247) do
   create_table "idea_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "idea_id", null: false
     t.string "image"
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_20_040355) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+    t.datetime "text_updated_at"
     t.index ["user_id"], name: "index_stories_on_user_id"
   end
 
@@ -94,6 +95,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_20_040355) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "marker"
+    t.datetime "text_updated_at"
     t.index ["story_id"], name: "index_story_elements_on_story_id"
   end
 
@@ -126,6 +128,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_20_040355) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "idea_id"
+    t.datetime "text_updated_at"
     t.index ["idea_id"], name: "index_story_event_ideas_on_idea_id"
     t.index ["story_event_id"], name: "index_story_event_ideas_on_story_event_id"
   end
@@ -145,6 +148,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_20_040355) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "text_updated_at"
     t.index ["story_id", "position"], name: "index_story_events_on_story_id_and_position"
     t.index ["story_id"], name: "index_story_events_on_story_id"
   end


### PR DESCRIPTION
登場要素を選択するページの表示を作成。編集と新規作成
- すべての主要ページに、作成日、更新日（文字修正のみ）を表示させる✅

✅ストーリー詳細（編集の横）

✅イベント詳細（編集の横）

✅イベント詳細メモの詳細（編集の横）

✅要素の詳細（編集の横）

✅要素の編集の戻り先を詳細に変更