### PR TITLE
Add breadcrumbs to story and idea related pages

### DIFF
--- a/app/controllers/ai_generations_controller.rb
+++ b/app/controllers/ai_generations_controller.rb
@@ -1,11 +1,13 @@
 # rubocop:disable Metrics/ClassLength
 class AiGenerationsController < ApplicationController
   before_action :require_login
+  before_action :set_breadcrumbs, only: %i[create]
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def create
     store_ai_context
     prepare_marker_select_for_ai
+    set_breadcrumbs
 
     word1 = params[:word1].to_s.strip
     word2 = params[:word2].to_s.strip
@@ -73,6 +75,61 @@ class AiGenerationsController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   private
+
+  def set_breadcrumbs
+    placeable = find_placeable_for_current_user(ai_placeable_type.to_s, ai_placeable_id.to_s)
+    @breadcrumbs = breadcrumb_items_for_placeable(placeable)
+  end
+
+  def breadcrumb_items_for_placeable(placeable)
+    case placeable
+    when Story
+      story_breadcrumbs(placeable)
+    when StoryEvent
+      story_event_breadcrumbs(placeable)
+    when StoryEventIdea
+      story_event_idea_breadcrumbs(placeable)
+    when StoryElement
+      story_element_breadcrumbs(placeable)
+    else
+      []
+    end
+  end
+
+  def story_breadcrumbs(story)
+    [
+      { name: story.title, path: nil }
+    ]
+  end
+
+  def story_event_breadcrumbs(story_event)
+    story = story_event.story
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: nil }
+    ]
+  end
+
+  def story_event_idea_breadcrumbs(story_event_idea)
+    story_event = story_event_idea.story_event
+    story = story_event.story
+
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: story_story_event_path(story, story_event) },
+      { name: story_event_idea.title, path: nil }
+    ]
+  end
+
+  def story_element_breadcrumbs(story_element)
+    story = story_element.story
+
+    [
+      { name: story.title, path: story_path(story) },
+      { name: "要素一覧", path: story_story_elements_path(story) },
+      { name: story_element.name, path: nil }
+    ]
+  end
 
   # rubocop:disable Metrics/AbcSize
   def store_ai_context

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -5,6 +5,8 @@ class IdeasController < ApplicationController
   before_action :sync_search_story_context_from_placeable, only: %i[new create]
   before_action :set_idea, only: %i[show edit update destroy]
   before_action :sync_search_story_context_from_idea, only: %i[show edit update]
+  before_action :set_breadcrumbs_for_new, only: %i[new]
+  before_action :set_breadcrumbs_for_existing_idea, only: %i[show edit]
 
   def index
     @ideas = current_user.ideas
@@ -41,7 +43,7 @@ class IdeasController < ApplicationController
     set_available_story_elements
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def create
     @idea = current_user.ideas.new(idea_params)
     @idea.build_idea_image if @idea.idea_image.nil?
@@ -64,10 +66,12 @@ class IdeasController < ApplicationController
     else
       @idea.build_idea_image if @idea.idea_image.nil?
       set_available_story_elements
+      placeable = find_placeable_for_current_user(pt || params[:placeable_type], pid || params[:placeable_id])
+      assign_breadcrumbs_from_placeable(placeable)
       render :new, status: :unprocessable_entity
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def edit
     @idea.build_idea_image if @idea.idea_image.nil?
@@ -79,6 +83,7 @@ class IdeasController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def update
     filtered_params = idea_params
     filtered_params = filtered_params.except(:idea_placement_attributes) if @idea.idea_placement.blank?
@@ -99,9 +104,11 @@ class IdeasController < ApplicationController
         @available_story_elements = []
       end
 
+      set_breadcrumbs_for_existing_idea
       render :edit, status: :unprocessable_entity
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Metrics/AbcSize
   def destroy
@@ -129,6 +136,70 @@ class IdeasController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   private
+
+  def set_breadcrumbs_for_new
+    placeable = find_placeable_for_current_user(params[:placeable_type], params[:placeable_id])
+    assign_breadcrumbs_from_placeable(placeable)
+  end
+
+  def set_breadcrumbs_for_existing_idea
+    placeable = @idea.idea_placement&.placeable
+    assign_breadcrumbs_from_placeable(placeable)
+  end
+
+  def assign_breadcrumbs_from_placeable(placeable)
+    @breadcrumbs = breadcrumb_items_for_placeable(placeable)
+  end
+
+  def breadcrumb_items_for_placeable(placeable)
+    case placeable
+    when Story
+      story_breadcrumbs(placeable)
+    when StoryEvent
+      story_event_breadcrumbs(placeable)
+    when StoryEventIdea
+      story_event_idea_breadcrumbs(placeable)
+    when StoryElement
+      story_element_breadcrumbs(placeable)
+    else
+      []
+    end
+  end
+
+  def story_breadcrumbs(story)
+    [
+      { name: story.title, path: nil }
+    ]
+  end
+
+  def story_event_breadcrumbs(story_event)
+    story = story_event.story
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: nil }
+    ]
+  end
+
+  def story_event_idea_breadcrumbs(story_event_idea)
+    story_event = story_event_idea.story_event
+    story = story_event.story
+
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: story_story_event_path(story, story_event) },
+      { name: story_event_idea.title, path: nil }
+    ]
+  end
+
+  def story_element_breadcrumbs(story_element)
+    story = story_element.story
+
+    [
+      { name: story.title, path: story_path(story) },
+      { name: "要素一覧", path: story_story_elements_path(story) },
+      { name: story_element.name, path: nil }
+    ]
+  end
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def sync_search_story_context_from_placeable

--- a/app/controllers/random_words_controller.rb
+++ b/app/controllers/random_words_controller.rb
@@ -1,5 +1,7 @@
+# rubocop:disable Metrics/ClassLength
 class RandomWordsController < ApplicationController
   before_action :require_login
+  before_action :set_breadcrumbs, only: %i[pick]
 
   def pick
     return render_not_enough_words if RandomWord.noun.count < 1 || RandomWord.verb.count < 1
@@ -10,6 +12,74 @@ class RandomWordsController < ApplicationController
   end
 
   private
+
+  def set_breadcrumbs
+    placeable = find_placeable_for_current_user(params[:placeable_type], params[:placeable_id])
+    @breadcrumbs = breadcrumb_items_for_placeable(placeable)
+  end
+
+  def breadcrumb_items_for_placeable(placeable)
+    case placeable
+    when Story
+      story_breadcrumbs(placeable)
+    when StoryEvent
+      story_event_breadcrumbs(placeable)
+    when StoryEventIdea
+      story_event_idea_breadcrumbs(placeable)
+    when StoryElement
+      story_element_breadcrumbs(placeable)
+    else
+      []
+    end
+  end
+
+  def story_breadcrumbs(story)
+    [
+      { name: story.title, path: nil }
+    ]
+  end
+
+  def story_event_breadcrumbs(story_event)
+    story = story_event.story
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: nil }
+    ]
+  end
+
+  def story_event_idea_breadcrumbs(story_event_idea)
+    story_event = story_event_idea.story_event
+    story = story_event.story
+
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: story_story_event_path(story, story_event) },
+      { name: story_event_idea.title, path: nil }
+    ]
+  end
+
+  def story_element_breadcrumbs(story_element)
+    story = story_element.story
+
+    [
+      { name: story.title, path: story_path(story) },
+      { name: "要素一覧", path: story_story_elements_path(story) },
+      { name: story_element.name, path: nil }
+    ]
+  end
+
+  def find_placeable_for_current_user(type, id)
+    case type.to_s
+    when "Story"
+      current_user.stories.find_by(id: id)
+    when "StoryEvent"
+      StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    when "StoryElement"
+      StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    when "StoryEventIdea"
+      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    end
+  end
 
   def render_not_enough_words
     @message = "名詞と動詞の辞書ワードがそれぞれ1件以上必要です。seedを追加してください。"
@@ -62,3 +132,4 @@ class RandomWordsController < ApplicationController
     %w[noun verb].include?(value) ? value : "noun"
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -3,6 +3,7 @@ class StoriesController < ApplicationController
   before_action :require_login
   before_action :set_story, only: %i[show edit update destroy consistency]
   before_action :sync_search_story_session, only: %i[show consistency]
+  before_action :set_breadcrumbs, only: %i[show edit consistency]
 
   def index
     @stories = current_user.stories.order(:position, created_at: :desc)
@@ -15,15 +16,13 @@ class StoriesController < ApplicationController
 
     base =
       @story.placed_ideas
-            .includes(idea_placement: :story_elements) # ✅ 複数マーカー表示用
+            .includes(idea_placement: :story_elements)
             .joins(:idea_placement)
             .order(created_at: :desc)
 
-    # このストーリー内で「ここで新規作成」されたアイデア（created_here: true）
     @created_here_ideas =
       base.where(idea_placements: { created_here: true })
 
-    # 「ここに移動したアイデア」（created_here: false）
     @moved_ideas =
       base.where(idea_placements: { created_here: false })
   end
@@ -134,6 +133,23 @@ class StoriesController < ApplicationController
 
   def set_story
     @story = current_user.stories.find(params[:id])
+  end
+
+  def set_breadcrumbs
+    @breadcrumbs =
+      case action_name
+      when "show", "edit"
+        [
+          { name: @story.title, path: nil }
+        ]
+      when "consistency"
+        [
+          { name: @story.title, path: story_path(@story) },
+          { name: "整合性チェック", path: nil }
+        ]
+      else
+        []
+      end
   end
 
   # ✅ ストーリー配下に入ったら「この作品」を session に固定

--- a/app/controllers/story_elements_controller.rb
+++ b/app/controllers/story_elements_controller.rb
@@ -3,6 +3,7 @@ class StoryElementsController < ApplicationController
   before_action :set_story
   before_action :set_story_element, only: %i[show edit update destroy]
   before_action :sync_search_story_session, only: %i[index show new edit]
+  before_action :set_breadcrumbs, only: %i[index show new edit]
 
   def index
     @story_elements = @story.story_elements.order(:id)
@@ -40,6 +41,10 @@ class StoryElementsController < ApplicationController
     if @story_element.save
       redirect_to story_story_elements_path(@story), notice: t(".success")
     else
+      @breadcrumbs = [
+        { name: @story.title, path: story_path(@story) },
+        { name: "要素一覧", path: nil }
+      ]
       render :new, status: :unprocessable_entity
     end
   end
@@ -49,6 +54,11 @@ class StoryElementsController < ApplicationController
       redirect_to story_story_element_path(@story, @story_element), notice: t(".success")
     else
       @story_element.build_story_element_image if @story_element.story_element_image.nil?
+      @breadcrumbs = [
+        { name: @story.title, path: story_path(@story) },
+        { name: "要素一覧", path: story_story_elements_path(@story) },
+        { name: @story_element.name, path: nil }
+      ]
       render :edit, status: :unprocessable_entity
     end
   end
@@ -66,6 +76,25 @@ class StoryElementsController < ApplicationController
 
   def set_story_element
     @story_element = @story.story_elements.find(params[:id])
+  end
+
+  def set_breadcrumbs
+    @breadcrumbs =
+      case action_name
+      when "index", "new"
+        [
+          { name: @story.title, path: story_path(@story) },
+          { name: "要素一覧", path: nil }
+        ]
+      when "show", "edit"
+        [
+          { name: @story.title, path: story_path(@story) },
+          { name: "要素一覧", path: story_story_elements_path(@story) },
+          { name: @story_element.name, path: nil }
+        ]
+      else
+        []
+      end
   end
 
   # ✅ ストーリー配下に入ったら「この作品」を session に固定

--- a/app/controllers/story_event_ideas_controller.rb
+++ b/app/controllers/story_event_ideas_controller.rb
@@ -1,8 +1,10 @@
+# rubocop:disable Metrics/ClassLength
 # app/controllers/story_event_ideas_controller.rb
 class StoryEventIdeasController < ApplicationController
   before_action :require_login
   before_action :set_story_and_event
   before_action :set_story_event_idea, only: %i[show edit update destroy move_up move_down]
+  before_action :set_breadcrumbs, only: %i[show new edit]
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def show
@@ -49,6 +51,10 @@ class StoryEventIdeasController < ApplicationController
     if @story_event_idea.save
       redirect_to story_story_event_path(@story, @story_event), notice: t("flash.story_event_ideas.created")
     else
+      @breadcrumbs = [
+        { name: @story.title, path: story_path(@story) },
+        { name: @story_event.title, path: nil }
+      ]
       render :new, status: :unprocessable_entity
     end
   end
@@ -58,6 +64,11 @@ class StoryEventIdeasController < ApplicationController
       redirect_to story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea),
                   notice: t("flash.story_event_ideas.updated")
     else
+      @breadcrumbs = [
+        { name: @story.title, path: story_path(@story) },
+        { name: @story_event.title, path: story_story_event_path(@story, @story_event) },
+        { name: @story_event_idea.title, path: nil }
+      ]
       render :edit, status: :unprocessable_entity
     end
   end
@@ -102,9 +113,28 @@ class StoryEventIdeasController < ApplicationController
                                     .find(params[:id])
   end
 
+  def set_breadcrumbs
+    @breadcrumbs =
+      case action_name
+      when "show", "edit"
+        [
+          { name: @story.title, path: story_path(@story) },
+          { name: @story_event.title, path: story_story_event_path(@story, @story_event) },
+          { name: @story_event_idea.title, path: nil }
+        ]
+      when "new"
+        [
+          { name: @story.title, path: story_path(@story) },
+          { name: @story_event.title, path: nil }
+        ]
+      else
+        []
+      end
+  end
+
   def story_event_idea_params
     params.require(:story_event_idea).permit(
-      :title, :memo, :image, :position,
+      :title, :memo, :image, :remove_image, :position,
       :idea_id,
       story_element_ids: []
     )
@@ -122,3 +152,4 @@ class StoryEventIdeasController < ApplicationController
     (story_event.story_event_ideas.maximum(:position) || 0) + 10
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/story_events_controller.rb
+++ b/app/controllers/story_events_controller.rb
@@ -1,9 +1,11 @@
+# rubocop:disable Metrics/ClassLength
 # app/controllers/story_events_controller.rb
 class StoryEventsController < ApplicationController
   before_action :require_login
   before_action :set_story
   before_action :set_story_event, only: %i[show edit update destroy move_up move_down]
   before_action :sync_search_story_session, only: %i[show new edit]
+  before_action :set_breadcrumbs, only: %i[show new edit]
 
   def show
     @current_story = @story
@@ -39,6 +41,9 @@ class StoryEventsController < ApplicationController
       redirect_to story_path(@story), notice: t(".success")
     else
       @story_event.build_story_event_image if @story_event.story_event_image.nil?
+      @breadcrumbs = [
+        { name: @story.title, path: nil }
+      ]
       render :new, status: :unprocessable_entity
     end
   end
@@ -48,6 +53,10 @@ class StoryEventsController < ApplicationController
       redirect_to story_story_event_path(@story, @story_event), notice: t(".success")
     else
       @story_event.build_story_event_image if @story_event.story_event_image.nil?
+      @breadcrumbs = [
+        { name: @story.title, path: story_path(@story) },
+        { name: @story_event.title, path: nil }
+      ]
       render :edit, status: :unprocessable_entity
     end
   end
@@ -95,6 +104,23 @@ class StoryEventsController < ApplicationController
                          .find(params[:id])
   end
 
+  def set_breadcrumbs
+    @breadcrumbs =
+      case action_name
+      when "show", "edit"
+        [
+          { name: @story.title, path: story_path(@story) },
+          { name: @story_event.title, path: nil }
+        ]
+      when "new"
+        [
+          { name: @story.title, path: nil }
+        ]
+      else
+        []
+      end
+  end
+
   # ✅ ストーリー配下に入ったら「この作品」を session に固定
   def sync_search_story_session
     session[:search_story_id] = @story.id
@@ -121,3 +147,4 @@ class StoryEventsController < ApplicationController
     (story.story_events.maximum(:position) || 0) + 10
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -47,6 +47,13 @@
         <div style="margin-top: 8px;">
           <%= image_tag idea.idea_image.image.url, style: "max-width: 320px; height: auto;" %>
         </div>
+
+        <div style="margin-top: 8px;">
+          <label>
+            <%= imgf.check_box :remove_image %>
+            画像を消す（アイデアの更新により反映されます。）
+          </label>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/ideas/edit.html.erb
+++ b/app/views/ideas/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <%= link_to "詳細へ戻る", idea_path(@idea) %>
 
 <h1>アイデア編集</h1>

--- a/app/views/ideas/new.html.erb
+++ b/app/views/ideas/new.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <%= link_to "戻る", (params[:return_to].presence || ideas_path) %>
 
 <h1>アイデア投稿</h1>

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <% placement = @idea.idea_placement %>
 
 <%

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,17 +1,25 @@
 <h1>パスワード再設定</h1>
 
 <%= form_with model: @user, url: password_reset_path(@token), method: :patch do |f| %>
-  <div>
-    <%= f.label :password, "新しいパスワード" %><br>
-    <%= f.password_field :password, required: true %>
+  <div style="margin-bottom: 16px;">
+    <%= f.label :password, "新しいパスワード（8文字以上72文字以下で入力してください）" %><br>
+    <%= f.password_field :password,
+                         required: true,
+                         minlength: 8,
+                         maxlength: 72,
+                         style: "width: 100%; max-width: 720px; padding: 10px; box-sizing: border-box;" %>
   </div>
 
-  <div>
+  <div style="margin-bottom: 40px;">
     <%= f.label :password_confirmation, "新しいパスワード（確認）" %><br>
-    <%= f.password_field :password_confirmation, required: true %>
+    <%= f.password_field :password_confirmation,
+                         required: true,
+                         minlength: 8,
+                         maxlength: 72,
+                         style: "width: 100%; max-width: 720px; padding: 10px; box-sizing: border-box;" %>
   </div>
 
-  <div>
-    <%= f.submit "更新する" %>
+  <div style="margin-bottom: 4em;">
+    <%= f.submit "更新する", style: "padding: 10px 20px;" %>
   </div>
 <% end %>

--- a/app/views/random_words/pick.html.erb
+++ b/app/views/random_words/pick.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <%= link_to "戻る", params[:return_to].presence || ideas_path %>
 
 <h1>ランダム辞書ワード</h1>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,9 +1,9 @@
 <!-- app/views/search/index.html.erb -->
-<h1>検索結果</h1>
-
 <p>
   <%= link_to "ストーリー一覧へ", stories_path %>
 </p>
+<h1>検索結果</h1>
+
 <hr>
 
 <% q = @query.to_s %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,92 @@
+<% return if items.blank? %>
+
+<nav class="breadcrumbs" aria-label="パンくず">
+  <ol class="breadcrumbs__list">
+    <% items.each_with_index do |item, index| %>
+      <% last_item = index == items.size - 1 %>
+
+      <li class="breadcrumbs__item">
+        <% if last_item %>
+          <span
+            class="breadcrumbs__current"
+            aria-current="page"
+            title="<%= item[:name] %>"
+          >
+            <%= item[:name] %>
+          </span>
+        <% else %>
+          <%= link_to item[:name], item[:path], class: "breadcrumbs__link", title: item[:name] %>
+        <% end %>
+
+        <% unless last_item %>
+          <span class="breadcrumbs__separator" aria-hidden="true">＞</span>
+        <% end %>
+      </li>
+    <% end %>
+  </ol>
+</nav>
+
+<style>
+  .breadcrumbs {
+    margin: 8px 0 10px;
+    font-size: 12px;
+    line-height: 1.4;
+  }
+
+  .breadcrumbs__list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 2px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .breadcrumbs__item {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .breadcrumbs__link,
+  .breadcrumbs__current {
+    display: inline-block;
+    max-width: 18ch;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+  }
+
+  .breadcrumbs__link {
+    color: #0d6efd;
+    text-decoration: none;
+  }
+
+  .breadcrumbs__link:hover {
+    text-decoration: underline;
+  }
+
+  .breadcrumbs__current {
+    color: #555;
+  }
+
+  .breadcrumbs__separator {
+    margin: 0 2px;
+    color: #888;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 767.98px) {
+    .breadcrumbs {
+      font-size: 11px;
+    }
+
+    .breadcrumbs__link,
+    .breadcrumbs__current {
+      max-width: 12ch;
+    }
+  }
+</style>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -39,6 +39,13 @@
         <div style="margin-top: 8px;">
           <%= image_tag story.story_image.image.url, style: "max-width: 320px; height: auto;" %>
         </div>
+
+        <div style="margin-top: 8px;">
+          <label>
+            <%= imgf.check_box :remove_image %>
+            画像を消す（ストーリーの更新により反映されます。）
+          </label>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/stories/consistency.html.erb
+++ b/app/views/stories/consistency.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p><%= link_to "ストーリー詳細へ戻る", story_path(@story) %></p>
 
 <h1>整合性チェック</h1>

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p><%= link_to "戻る", story_path(@story) %></p>
 <h1>ストーリー編集</h1>
 <%= render "form", story: @story %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p><%= link_to "ストーリー一覧へ", stories_path %></p>
 
 <h1><%= @story.title %></h1>

--- a/app/views/story_elements/_form.html.erb
+++ b/app/views/story_elements/_form.html.erb
@@ -65,6 +65,13 @@
         <div style="margin-top: 8px;">
           <%= image_tag @story_element.story_element_image.image.url, style: "max-width: 320px; height: auto;" %>
         </div>
+
+        <div style="margin-top: 8px;">
+          <label>
+            <%= imgf.check_box :remove_image %>
+            画像を消す（要素の更新により反映されます。）
+          </label>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/story_elements/edit.html.erb
+++ b/app/views/story_elements/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <%= link_to "戻る", story_story_element_path(@story, @story_element) %>
 
 <h1>要素編集</h1>

--- a/app/views/story_elements/index.html.erb
+++ b/app/views/story_elements/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <%= link_to "ストーリー詳細へ戻る", story_path(@story) %>
 
 <h1>要素一覧</h1>
@@ -20,7 +22,6 @@
       <li>
         <%= link_to "#{e.marker.present? ? "#{e.marker}　" : ""}#{e.name}",
                     story_story_element_path(@story, e) %>
-        <%# 削除は編集画面だけにしたいので、ここでは出さない %>
       </li>
     <% end %>
   </ul>

--- a/app/views/story_elements/new.html.erb
+++ b/app/views/story_elements/new.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <%= link_to "戻る", story_story_elements_path(@story) %>
 <h1>要素追加</h1>
 <%= render "form" %>

--- a/app/views/story_elements/show.html.erb
+++ b/app/views/story_elements/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p><%= link_to "要素一覧へ戻る", story_story_elements_path(@story) %></p>
 
 <h1>要素詳細</h1>

--- a/app/views/story_event_ideas/_form.html.erb
+++ b/app/views/story_event_ideas/_form.html.erb
@@ -40,6 +40,13 @@
       <div style="margin-top: 8px;">
         <%= image_tag @story_event_idea.image.url, style: "max-width: 320px; height: auto;" %>
       </div>
+
+      <div style="margin-top: 8px;">
+        <label>
+          <%= f.check_box :remove_image %>
+          画像を消す（詳細メモの更新により反映されます。）
+        </label>
+      </div>
     <% end %>
   </div>
 

--- a/app/views/story_event_ideas/edit.html.erb
+++ b/app/views/story_event_ideas/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p>
   <%= link_to "戻る", story_story_event_story_event_idea_path(@story, @story_event, @story_event_idea) %>
 </p>

--- a/app/views/story_event_ideas/new.html.erb
+++ b/app/views/story_event_ideas/new.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p>
   <%= link_to "戻る", story_story_event_path(@story, @story_event) %>
 </p>
@@ -5,5 +7,3 @@
 <h1>詳細メモ追加</h1>
 
 <%= render "form" %>
-
-

--- a/app/views/story_event_ideas/show.html.erb
+++ b/app/views/story_event_ideas/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p>
   <%= link_to "イベント詳細へ戻る", story_story_event_path(@story, @story_event) %>
 </p>

--- a/app/views/story_events/_form.html.erb
+++ b/app/views/story_events/_form.html.erb
@@ -44,6 +44,13 @@
         <div style="margin-top: 8px;">
           <%= image_tag @story_event.story_event_image.image.url, style: "max-width: 320px; height: auto;" %>
         </div>
+
+        <div style="margin-top: 8px;">
+          <label>
+            <%= imgf.check_box :remove_image %>
+            画像を消す（イベントの更新により反映されます。）
+          </label>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/story_events/edit.html.erb
+++ b/app/views/story_events/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <%= link_to "戻る", story_story_event_path(@story, @story_event) %>
 <h1>イベント編集</h1>
 <%= render "form" %>

--- a/app/views/story_events/new.html.erb
+++ b/app/views/story_events/new.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p><%= link_to "戻る", story_path(@story) %></p>
 <h1>イベント追加</h1>
 <%= render "form" %>

--- a/app/views/story_events/show.html.erb
+++ b/app/views/story_events/show.html.erb
@@ -1,5 +1,7 @@
+<%= render "shared/breadcrumbs", items: @breadcrumbs %>
+
 <p>
-  <%= link_to "ストーリー詳細へ戻る", story_path(@story) %> 
+  <%= link_to "ストーリー詳細へ戻る", story_path(@story) %>
 </p>
 
 <h1><%= @story_event.title %></h1>


### PR DESCRIPTION
✅パスワード再設定画面の修正

✅全ページの画像を扱うページ（すべて？）一度画像を選んで保存すると、画像をなしにできないので修正

🟣画像削除機能実装

✅ストーリー編集

**✅イベント編集**

**✅イベント詳細メモ編集**

✅アイデア編集

✅要素

さらに、パンクズ設定