### PR TITLE
画像アップロードを含む保存フォームにローディング表示を追加

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -93,3 +93,22 @@ hr {
 .privacy-page {
   color: #f5f5f5;
 }
+
+/* 保存ボタンを押した直後に表示する、くるくる回るローディング表示 */
+.inline-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  vertical-align: middle;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: inline-spinner-spin 0.7s linear infinite;
+}
+
+@keyframes inline-spinner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/javascript/controllers/saving_indicator_controller.js
+++ b/app/javascript/controllers/saving_indicator_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// フォームを送信（保存）した直後に、保存ボタンの近くへ
+// スピナー付きの「保存中です…」を表示する。
+// ページ遷移（Turbo Drive）が完了すれば、この表示ごと画面が切り替わるので消える。
+export default class extends Controller {
+  static targets = ["indicator"]
+
+  show() {
+    if (!this.hasIndicatorTarget) return
+
+    this.indicatorTarget.hidden = false
+  }
+}

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -11,8 +11,8 @@
               local: true,
               html: { multipart: true },
               data: {
-                controller: "prevent-enter-submit element-selector",
-                action: "keydown->prevent-enter-submit#check change->element-selector#refresh"
+                controller: "prevent-enter-submit element-selector saving-indicator",
+                action: "keydown->prevent-enter-submit#check change->element-selector#refresh submit->saving-indicator#show"
               }) do |f| %>
   <% if idea.errors.any? %>
     <div class="alert alert-danger">
@@ -159,5 +159,9 @@
   <div style="margin-top: 30px;">
     <%= f.submit(idea.persisted? ? "アイデアの更新" : "アイデアを作成",
           style: "background: #2563eb; color: #ffffff; border: none; border-radius: 8px; padding: 12px 24px; font-weight: bold; cursor: pointer;") %>
+
+    <span data-saving-indicator-target="indicator" hidden style="margin-left: 14px; font-weight: bold; color: #ddd6fe;">
+      <span class="inline-spinner"></span>保存中です…
+    </span>
   </div>
 <% end %>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: story, html: { multipart: true }, data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
+<%= form_with model: story, html: { multipart: true }, data: { controller: "prevent-enter-submit saving-indicator", action: "keydown->prevent-enter-submit#check submit->saving-indicator#show" } do |f| %>
   <% if story.errors.any? %>
     <ul>
       <% story.errors.full_messages.each do |msg| %>
@@ -53,5 +53,9 @@
   <div style="margin-top: 30px;">
     <%= f.submit(story.persisted? ? "ストーリーを更新" : "ストーリーを作成",
           style: "background: #2563eb; color: #ffffff; border: none; border-radius: 8px; padding: 12px 24px; font-weight: bold; cursor: pointer;") %>
+
+    <span data-saving-indicator-target="indicator" hidden style="margin-left: 14px; font-weight: bold; color: #ddd6fe;">
+      <span class="inline-spinner"></span>保存中です…
+    </span>
   </div>
 <% end %>

--- a/app/views/story_elements/_form.html.erb
+++ b/app/views/story_elements/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: [@story, @story_element],
               url: @story_element.persisted? ? story_story_element_path(@story, @story_element, breadcrumb_params) : story_story_elements_path(@story, breadcrumb_params),
-              data: { controller: "prevent-enter-submit", action: "keydown->prevent-enter-submit#check" } do |f| %>
+              data: { controller: "prevent-enter-submit saving-indicator", action: "keydown->prevent-enter-submit#check submit->saving-indicator#show" } do |f| %>
   <% if @story_element.errors.any? %>
     <ul>
       <% @story_element.errors.full_messages.each do |msg| %>
@@ -80,5 +80,9 @@
   <div style="margin-top: 24px;">
     <%= f.submit "要素を保存する",
           style: "background: #2563eb; color: #ffffff; border: none; border-radius: 8px; padding: 12px 24px; font-weight: bold; cursor: pointer;" %>
+
+    <span data-saving-indicator-target="indicator" hidden style="margin-left: 14px; font-weight: bold; color: #ddd6fe;">
+      <span class="inline-spinner"></span>保存中です…
+    </span>
   </div>
 <% end %>

--- a/app/views/story_event_ideas/_form.html.erb
+++ b/app/views/story_event_ideas/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@story, @story_event, @story_event_idea],
               data: {
-                controller: "prevent-enter-submit element-selector",
-                action: "keydown->prevent-enter-submit#check change->element-selector#refresh"
+                controller: "prevent-enter-submit element-selector saving-indicator",
+                action: "keydown->prevent-enter-submit#check change->element-selector#refresh submit->saving-indicator#show"
               } do |f| %>
   <% if @story_event_idea.errors.any? %>
     <ul>
@@ -125,5 +125,9 @@
   <div style="margin-top: 24px;">
     <%= f.submit @story_event_idea.persisted? ? "詳細メモを更新する" : "詳細メモを追加する",
           style: "background: #2563eb; color: #ffffff; border: none; border-radius: 8px; padding: 12px 24px; font-weight: bold; cursor: pointer;" %>
+
+    <span data-saving-indicator-target="indicator" hidden style="margin-left: 14px; font-weight: bold; color: #ddd6fe;">
+      <span class="inline-spinner"></span>保存中です…
+    </span>
   </div>
 <% end %>

--- a/app/views/story_events/_form.html.erb
+++ b/app/views/story_events/_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_with model: [@story, @story_event],
               html: { multipart: true },
               data: {
-                controller: "prevent-enter-submit element-selector",
-                action: "keydown->prevent-enter-submit#check change->element-selector#refresh"
+                controller: "prevent-enter-submit element-selector saving-indicator",
+                action: "keydown->prevent-enter-submit#check change->element-selector#refresh submit->saving-indicator#show"
               } do |f| %>
   <% if @story_event.errors.any? %>
     <ul>
@@ -130,5 +130,9 @@
   <div style="margin-top: 24px;">
     <%= f.submit "イベントを保存する",
           style: "background: #2563eb; color: #ffffff; border: none; border-radius: 8px; padding: 12px 24px; font-weight: bold; cursor: pointer;" %>
+
+    <span data-saving-indicator-target="indicator" hidden style="margin-left: 14px; font-weight: bold; color: #ddd6fe;">
+      <span class="inline-spinner"></span>保存中です…
+    </span>
   </div>
 <% end %>


### PR DESCRIPTION
- Stimulusコントローラ(saving_indicator_controller.js)を新規追加し、 フォーム送信直後にスピナー付き「保存中です…」を表示する
- くるくる回るスピナーのCSSをapplication.css.erbに追加
- アイデア/ストーリー/要素/イベント/イベント詳細メモの 5つの保存フォームに組み込み