### PR TITLE
パンくずリスト生成ロジックをconcernに切り出し、controllerの重複を解消

### DIFF
--- a/app/controllers/ai_generations_controller.rb
+++ b/app/controllers/ai_generations_controller.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Metrics/ClassLength
 class AiGenerationsController < ApplicationController
+  include PlaceableBreadcrumbs
+
   before_action :require_login
   before_action :set_breadcrumbs, only: %i[create]
 
@@ -81,56 +83,6 @@ class AiGenerationsController < ApplicationController
     @breadcrumbs = breadcrumb_items_for_placeable(placeable)
   end
 
-  def breadcrumb_items_for_placeable(placeable)
-    case placeable
-    when Story
-      story_breadcrumbs(placeable)
-    when StoryEvent
-      story_event_breadcrumbs(placeable)
-    when StoryEventIdea
-      story_event_idea_breadcrumbs(placeable)
-    when StoryElement
-      story_element_breadcrumbs(placeable)
-    else
-      []
-    end
-  end
-
-  def story_breadcrumbs(story)
-    [
-      { name: story.title, path: nil }
-    ]
-  end
-
-  def story_event_breadcrumbs(story_event)
-    story = story_event.story
-    [
-      { name: story.title, path: story_path(story) },
-      { name: story_event.title, path: nil }
-    ]
-  end
-
-  def story_event_idea_breadcrumbs(story_event_idea)
-    story_event = story_event_idea.story_event
-    story = story_event.story
-
-    [
-      { name: story.title, path: story_path(story) },
-      { name: story_event.title, path: story_story_event_path(story, story_event) },
-      { name: story_event_idea.title, path: nil }
-    ]
-  end
-
-  def story_element_breadcrumbs(story_element)
-    story = story_element.story
-
-    [
-      { name: story.title, path: story_path(story) },
-      { name: "要素一覧", path: story_story_elements_path(story) },
-      { name: story_element.name, path: nil }
-    ]
-  end
-
   # rubocop:disable Metrics/AbcSize
   def store_ai_context
     rt = safe_path(params[:return_to])
@@ -187,19 +139,6 @@ class AiGenerationsController < ApplicationController
       marker: marker,
       moved_at: Time.current
     )
-  end
-
-  def find_placeable_for_current_user(type, id)
-    case type
-    when "Story"
-      current_user.stories.find_by(id: id)
-    when "StoryEvent"
-      StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    when "StoryElement"
-      StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    when "StoryEventIdea"
-      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    end
   end
 
   def prepare_marker_select_for_ai

--- a/app/controllers/concerns/placeable_breadcrumbs.rb
+++ b/app/controllers/concerns/placeable_breadcrumbs.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# 「アイデアの配置先（ストーリー／イベント／要素／イベント詳細メモ）」に応じて
+# パンくずリストの中身を組み立てる処理をまとめたconcern。
+#
+# もともとAiGenerationsController・RandomWordsController・IdeasControllerの
+# 3つに、ほぼ同じ内容のprivateメソッドが重複していたため、ここに集約した。
+# 挙動は移動前と変えていない（story_element_breadcrumbsに渡す
+# breadcrumb_paramsだけ、各controllerの呼び出し側で組み立てて渡すようにした）。
+# rubocop:disable Metrics/ModuleLength
+module PlaceableBreadcrumbs
+  extend ActiveSupport::Concern
+
+  private
+
+  def find_placeable_for_current_user(type, id)
+    case type.to_s
+    when "Story"
+      current_user.stories.find_by(id: id)
+    when "StoryEvent"
+      StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    when "StoryElement"
+      StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    when "StoryEventIdea"
+      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find_by(id: id)
+    end
+  end
+
+  def breadcrumb_items_for_placeable(placeable, breadcrumb_params = {})
+    case placeable
+    when Story
+      story_breadcrumbs(placeable)
+    when StoryEvent
+      story_event_breadcrumbs(placeable)
+    when StoryEventIdea
+      story_event_idea_breadcrumbs(placeable)
+    when StoryElement
+      story_element_breadcrumbs(placeable, breadcrumb_params)
+    else
+      []
+    end
+  end
+
+  def story_breadcrumbs(story)
+    [
+      { name: story.title, path: nil }
+    ]
+  end
+
+  def story_event_breadcrumbs(story_event)
+    story = story_event.story
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: nil }
+    ]
+  end
+
+  def story_event_idea_breadcrumbs(story_event_idea)
+    story_event = story_event_idea.story_event
+    story = story_event.story
+
+    [
+      { name: story.title, path: story_path(story) },
+      { name: story_event.title, path: story_story_event_path(story, story_event) },
+      { name: story_event_idea.title, path: nil }
+    ]
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+  def story_element_breadcrumbs(story_element, breadcrumb_params = {})
+    story = story_element.story
+
+    case breadcrumb_params[:from]
+    when "story_event_idea"
+      story_event = story.story_events.find_by(id: breadcrumb_params[:story_event_id])
+      story_event_idea = story_event&.story_event_ideas&.find_by(id: breadcrumb_params[:story_event_idea_id])
+
+      if story_event.present? && story_event_idea.present?
+        [
+          { name: story.title, path: story_path(story) },
+          { name: story_event.title, path: story_story_event_path(story, story_event) },
+          {
+            name: story_event_idea.title,
+            path: story_story_event_story_event_idea_path(story, story_event, story_event_idea)
+          },
+          { name: "要素一覧", path: story_story_elements_path(story, breadcrumb_params) },
+          { name: story_element.name, path: nil }
+        ]
+      else
+        [
+          { name: story.title, path: story_path(story) },
+          { name: "要素一覧", path: story_story_elements_path(story) },
+          { name: story_element.name, path: nil }
+        ]
+      end
+    when "story_event"
+      story_event = story.story_events.find_by(id: breadcrumb_params[:story_event_id])
+
+      if story_event.present?
+        [
+          { name: story.title, path: story_path(story) },
+          { name: story_event.title, path: story_story_event_path(story, story_event) },
+          { name: "要素一覧", path: story_story_elements_path(story, breadcrumb_params) },
+          { name: story_element.name, path: nil }
+        ]
+      else
+        [
+          { name: story.title, path: story_path(story) },
+          { name: "要素一覧", path: story_story_elements_path(story) },
+          { name: story_element.name, path: nil }
+        ]
+      end
+    else
+      [
+        { name: story.title, path: story_path(story) },
+        { name: "要素一覧", path: story_story_elements_path(story) },
+        { name: story_element.name, path: nil }
+      ]
+    end
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+  def return_to_breadcrumb_params
+    return {} if params[:return_to].blank?
+
+    query = URI.parse(params[:return_to]).query
+    return {} if query.blank?
+
+    parsed = Rack::Utils.parse_nested_query(query)
+
+    {
+      from: parsed["from"],
+      story_event_id: parsed["story_event_id"],
+      story_event_idea_id: parsed["story_event_idea_id"]
+    }.compact.symbolize_keys
+  rescue URI::InvalidURIError
+    {}
+  end
+end
+# rubocop:enable Metrics/ModuleLength

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,6 +1,8 @@
 # app/controllers/ideas_controller.rb
 # rubocop:disable Metrics/ClassLength
 class IdeasController < ApplicationController
+  include PlaceableBreadcrumbs
+
   before_action :require_login
   before_action :sync_search_story_context_from_placeable, only: %i[new create]
   before_action :set_idea, only: %i[show edit update destroy]
@@ -153,102 +155,8 @@ class IdeasController < ApplicationController
   end
 
   def assign_breadcrumbs_from_placeable(placeable)
-    @breadcrumbs = breadcrumb_items_for_placeable(placeable)
+    @breadcrumbs = breadcrumb_items_for_placeable(placeable, current_breadcrumb_params)
   end
-
-  def breadcrumb_items_for_placeable(placeable)
-    case placeable
-    when Story
-      story_breadcrumbs(placeable)
-    when StoryEvent
-      story_event_breadcrumbs(placeable)
-    when StoryEventIdea
-      story_event_idea_breadcrumbs(placeable)
-    when StoryElement
-      story_element_breadcrumbs(placeable, current_breadcrumb_params)
-    else
-      []
-    end
-  end
-
-  def story_breadcrumbs(story)
-    [
-      { name: story.title, path: nil }
-    ]
-  end
-
-  def story_event_breadcrumbs(story_event)
-    story = story_event.story
-    [
-      { name: story.title, path: story_path(story) },
-      { name: story_event.title, path: nil }
-    ]
-  end
-
-  def story_event_idea_breadcrumbs(story_event_idea)
-    story_event = story_event_idea.story_event
-    story = story_event.story
-
-    [
-      { name: story.title, path: story_path(story) },
-      { name: story_event.title, path: story_story_event_path(story, story_event) },
-      { name: story_event_idea.title, path: nil }
-    ]
-  end
-
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-  def story_element_breadcrumbs(story_element, breadcrumb_params = {})
-    story = story_element.story
-
-    case breadcrumb_params[:from]
-    when "story_event_idea"
-      story_event = story.story_events.find_by(id: breadcrumb_params[:story_event_id])
-      story_event_idea = story_event&.story_event_ideas&.find_by(id: breadcrumb_params[:story_event_idea_id])
-
-      if story_event.present? && story_event_idea.present?
-        [
-          { name: story.title, path: story_path(story) },
-          { name: story_event.title, path: story_story_event_path(story, story_event) },
-          {
-            name: story_event_idea.title,
-            path: story_story_event_story_event_idea_path(story, story_event, story_event_idea)
-          },
-          { name: "要素一覧", path: story_story_elements_path(story, breadcrumb_params) },
-          { name: story_element.name, path: nil }
-        ]
-      else
-        [
-          { name: story.title, path: story_path(story) },
-          { name: "要素一覧", path: story_story_elements_path(story) },
-          { name: story_element.name, path: nil }
-        ]
-      end
-    when "story_event"
-      story_event = story.story_events.find_by(id: breadcrumb_params[:story_event_id])
-
-      if story_event.present?
-        [
-          { name: story.title, path: story_path(story) },
-          { name: story_event.title, path: story_story_event_path(story, story_event) },
-          { name: "要素一覧", path: story_story_elements_path(story, breadcrumb_params) },
-          { name: story_element.name, path: nil }
-        ]
-      else
-        [
-          { name: story.title, path: story_path(story) },
-          { name: "要素一覧", path: story_story_elements_path(story) },
-          { name: story_element.name, path: nil }
-        ]
-      end
-    else
-      [
-        { name: story.title, path: story_path(story) },
-        { name: "要素一覧", path: story_story_elements_path(story) },
-        { name: story_element.name, path: nil }
-      ]
-    end
-  end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
 
   def current_breadcrumb_params
     return return_to_breadcrumb_params if params[:return_to].present?
@@ -258,23 +166,6 @@ class IdeasController < ApplicationController
       story_event_id: params[:story_event_id],
       story_event_idea_id: params[:story_event_idea_id]
     }.compact.symbolize_keys
-  end
-
-  def return_to_breadcrumb_params
-    return {} if params[:return_to].blank?
-
-    query = URI.parse(params[:return_to]).query
-    return {} if query.blank?
-
-    parsed = Rack::Utils.parse_nested_query(query)
-
-    {
-      from: parsed["from"],
-      story_event_id: parsed["story_event_id"],
-      story_event_idea_id: parsed["story_event_idea_id"]
-    }.compact.symbolize_keys
-  rescue URI::InvalidURIError
-    {}
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -386,19 +277,6 @@ class IdeasController < ApplicationController
   def safe_path(value)
     v = value.to_s
     v.start_with?("/") ? v : nil
-  end
-
-  def find_placeable_for_current_user(type, id)
-    case type.to_s
-    when "Story"
-      current_user.stories.find_by(id: id)
-    when "StoryEvent"
-      StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    when "StoryElement"
-      StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    when "StoryEventIdea"
-      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    end
   end
 
   def story_for_placeable(placeable)

--- a/app/controllers/random_words_controller.rb
+++ b/app/controllers/random_words_controller.rb
@@ -1,5 +1,6 @@
-# rubocop:disable Metrics/ClassLength
 class RandomWordsController < ApplicationController
+  include PlaceableBreadcrumbs
+
   before_action :require_login
   before_action :set_breadcrumbs, only: %i[pick]
 
@@ -15,131 +16,7 @@ class RandomWordsController < ApplicationController
 
   def set_breadcrumbs
     placeable = find_placeable_for_current_user(params[:placeable_type], params[:placeable_id])
-    @breadcrumbs = breadcrumb_items_for_placeable(placeable)
-  end
-
-  def breadcrumb_items_for_placeable(placeable)
-    case placeable
-    when Story
-      story_breadcrumbs(placeable)
-    when StoryEvent
-      story_event_breadcrumbs(placeable)
-    when StoryEventIdea
-      story_event_idea_breadcrumbs(placeable)
-    when StoryElement
-      story_element_breadcrumbs(placeable, return_to_breadcrumb_params)
-    else
-      []
-    end
-  end
-
-  def story_breadcrumbs(story)
-    [
-      { name: story.title, path: nil }
-    ]
-  end
-
-  def story_event_breadcrumbs(story_event)
-    story = story_event.story
-    [
-      { name: story.title, path: story_path(story) },
-      { name: story_event.title, path: nil }
-    ]
-  end
-
-  def story_event_idea_breadcrumbs(story_event_idea)
-    story_event = story_event_idea.story_event
-    story = story_event.story
-
-    [
-      { name: story.title, path: story_path(story) },
-      { name: story_event.title, path: story_story_event_path(story, story_event) },
-      { name: story_event_idea.title, path: nil }
-    ]
-  end
-
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-  def story_element_breadcrumbs(story_element, breadcrumb_params = {})
-    story = story_element.story
-
-    case breadcrumb_params[:from]
-    when "story_event_idea"
-      story_event = story.story_events.find_by(id: breadcrumb_params[:story_event_id])
-      story_event_idea = story_event&.story_event_ideas&.find_by(id: breadcrumb_params[:story_event_idea_id])
-
-      if story_event.present? && story_event_idea.present?
-        [
-          { name: story.title, path: story_path(story) },
-          { name: story_event.title, path: story_story_event_path(story, story_event) },
-          {
-            name: story_event_idea.title,
-            path: story_story_event_story_event_idea_path(story, story_event, story_event_idea)
-          },
-          { name: "要素一覧", path: story_story_elements_path(story, breadcrumb_params) },
-          { name: story_element.name, path: nil }
-        ]
-      else
-        [
-          { name: story.title, path: story_path(story) },
-          { name: "要素一覧", path: story_story_elements_path(story) },
-          { name: story_element.name, path: nil }
-        ]
-      end
-    when "story_event"
-      story_event = story.story_events.find_by(id: breadcrumb_params[:story_event_id])
-
-      if story_event.present?
-        [
-          { name: story.title, path: story_path(story) },
-          { name: story_event.title, path: story_story_event_path(story, story_event) },
-          { name: "要素一覧", path: story_story_elements_path(story, breadcrumb_params) },
-          { name: story_element.name, path: nil }
-        ]
-      else
-        [
-          { name: story.title, path: story_path(story) },
-          { name: "要素一覧", path: story_story_elements_path(story) },
-          { name: story_element.name, path: nil }
-        ]
-      end
-    else
-      [
-        { name: story.title, path: story_path(story) },
-        { name: "要素一覧", path: story_story_elements_path(story) },
-        { name: story_element.name, path: nil }
-      ]
-    end
-  end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-
-  def return_to_breadcrumb_params
-    return {} if params[:return_to].blank?
-
-    query = URI.parse(params[:return_to]).query
-    return {} if query.blank?
-
-    parsed = Rack::Utils.parse_nested_query(query)
-
-    {
-      from: parsed["from"],
-      story_event_id: parsed["story_event_id"],
-      story_event_idea_id: parsed["story_event_idea_id"]
-    }.compact.symbolize_keys
-  rescue URI::InvalidURIError
-    {}
-  end
-
-  def find_placeable_for_current_user(type, id)
-    case type.to_s
-    when "Story"
-      current_user.stories.find_by(id: id)
-    when "StoryEvent"
-      StoryEvent.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    when "StoryElement"
-      StoryElement.joins(:story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    when "StoryEventIdea"
-      StoryEventIdea.joins(story_event: :story).where(stories: { user_id: current_user.id }).find_by(id: id)
-    end
+    @breadcrumbs = breadcrumb_items_for_placeable(placeable, return_to_breadcrumb_params)
   end
 
   def render_not_enough_words
@@ -193,4 +70,3 @@ class RandomWordsController < ApplicationController
     %w[noun verb].include?(value) ? value : "noun"
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/spec/requests/breadcrumbs_spec.rb
+++ b/spec/requests/breadcrumbs_spec.rb
@@ -1,0 +1,97 @@
+# rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+require "rails_helper"
+
+# パンくずリスト生成ロジック（AiGenerationsController / RandomWordsController /
+# IdeasControllerに重複していた処理）をconcernへ切り出すにあたり、
+# 「切り出す前」と「切り出した後」で表示内容が変わっていないことを保証するための特性テスト。
+RSpec.describe "Breadcrumbs", type: :request do
+  let!(:user) { create(:user, password: "password") }
+
+  before do
+    post login_path, params: { email: user.email, password: "password" }
+  end
+
+  describe "GET /random_words/pick" do
+    let!(:story) { create(:story, user: user, title: "ストーリーA") }
+    let!(:story_event) { create(:story_event, story: story, title: "イベントA") }
+    let!(:story_event_idea) { create(:story_event_idea, story_event: story_event, title: "詳細メモA") }
+    let!(:story_element) { create(:story_element, story: story, name: "要素A") }
+
+    before do
+      RandomWord.create!(word: "テスト名詞#{SecureRandom.hex(4)}", part_of_speech: "noun")
+      RandomWord.create!(word: "テスト動詞#{SecureRandom.hex(4)}", part_of_speech: "verb")
+    end
+
+    it "placeable_typeがStoryのとき、ストーリー名だけのパンくずになる" do
+      get random_words_pick_path, params: { placeable_type: "Story", placeable_id: story.id }
+
+      expect(response.body).to include("ストーリーA")
+      expect(response.body).not_to include("イベントA")
+    end
+
+    it "placeable_typeがStoryEventのとき、ストーリー→イベントのパンくずになる" do
+      get random_words_pick_path, params: { placeable_type: "StoryEvent", placeable_id: story_event.id }
+
+      expect(response.body).to include("ストーリーA")
+      expect(response.body).to include("イベントA")
+    end
+
+    it "placeable_typeがStoryEventIdeaのとき、ストーリー→イベント→詳細メモのパンくずになる" do
+      get random_words_pick_path, params: { placeable_type: "StoryEventIdea", placeable_id: story_event_idea.id }
+
+      expect(response.body).to include("ストーリーA")
+      expect(response.body).to include("イベントA")
+      expect(response.body).to include("詳細メモA")
+    end
+
+    it "placeable_typeがStoryElementかつreturn_toが無いとき、ストーリー→要素一覧→要素名のパンくずになる" do
+      get random_words_pick_path, params: { placeable_type: "StoryElement", placeable_id: story_element.id }
+
+      expect(response.body).to include("ストーリーA")
+      expect(response.body).to include("要素一覧")
+      expect(response.body).to include("要素A")
+      expect(response.body).not_to include("イベントA")
+    end
+
+    it "placeable_typeがStoryElementかつreturn_toにfrom=story_eventが含まれるとき、イベント経由のパンくずになる" do
+      return_to = "/stories/#{story.id}/story_events/#{story_event.id}?from=story_event&story_event_id=#{story_event.id}"
+
+      get random_words_pick_path,
+          params: { placeable_type: "StoryElement", placeable_id: story_element.id, return_to: return_to }
+
+      expect(response.body).to include("ストーリーA")
+      expect(response.body).to include("イベントA")
+      expect(response.body).to include("要素一覧")
+      expect(response.body).to include("要素A")
+    end
+  end
+
+  describe "GET /ideas/new" do
+    let!(:story) { create(:story, user: user, title: "アイデア用ストーリー") }
+
+    it "placeable_typeがStoryのとき、ストーリー名のパンくずになる" do
+      get new_idea_path, params: { placeable_type: "Story", placeable_id: story.id }
+
+      expect(response.body).to include("アイデア用ストーリー")
+    end
+  end
+
+  describe "GET /ideas/:id/edit" do
+    let!(:story) { create(:story, user: user, title: "編集用ストーリー") }
+    let!(:story_element) { create(:story_element, story: story, name: "編集用要素") }
+    let!(:idea) { create(:idea, user: user, title: "対象アイデア") }
+
+    before do
+      create(:idea_placement, idea: idea, placeable: story_element, created_here: true)
+    end
+
+    it "配置先が要素のとき、ストーリー→要素一覧→要素名のパンくずになる" do
+      get edit_idea_path(idea)
+
+      expect(response.body).to include("編集用ストーリー")
+      expect(response.body).to include("要素一覧")
+      expect(response.body).to include("編集用要素")
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength


### PR DESCRIPTION
- AiGenerationsController・RandomWordsController・IdeasControllerの 3ファイルにほぼ同じ内容で重複していたパンくず生成メソッド群を app/controllers/concerns/placeable_breadcrumbs.rbに集約
- 切り出し前に、現状の表示内容を保証する特性テスト (spec/requests/breadcrumbs_spec.rb, 7ケース)を追加
- IdeasController: 415行→293行、RandomWordsController: 196行→74行 （Metrics/ClassLengthの無効化コメントも不要になった）
- 挙動は変更していないことを、自動テスト・RuboCop・ブラウザでの 全パターン目視確認で検証済み

コントローラーの分割: IdeasController（約250行）やSearchControllerが非常に大きく、複数のrubocop:disableコメントが入っています。パンくず生成ロジックをconcernやヘルパーに切り出すと、「リファクタリングの判断基準」を面接で語る材料になるかと思いました。の改善