### PR TITLE
Bulletを導入してN+1クエリを検出・修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,9 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 
+  # N+1クエリを検出して知らせてくれる [https://github.com/flyerhzm/bullet]
+  gem "bullet"
+
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
     bootsnap (1.20.1)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bullet (8.1.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -382,6 +385,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uniform_notifier (1.18.0)
     uri (1.1.1)
     version_gem (1.1.9)
     web-console (4.2.1)
@@ -413,6 +417,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
   carrierwave
   cloudinary

--- a/README.md
+++ b/README.md
@@ -71,8 +71,17 @@ Figma：https://www.figma.com/board/PpIwMCpGPlmi68IROYUKwE/%E7%94%BB%E9%9D%A2%E9
 | 認証 | sorcery |
 | 画像アップロード | carrierwave + Cloudinary |
 | AI連携 | OpenAI API（faraday経由でHTTPリクエスト） |
-| テスト / 静的解析 | RSpec、RuboCop |
+| テスト / 静的解析 | RSpec、RuboCop、Bullet（N+1クエリ検出） |
 | 開発環境 | Docker / Docker Compose |
+
+## パフォーマンスへの配慮
+
+開発環境にBulletを導入し、N+1クエリを検出できるようにしています。
+実際にBulletで検出し、対応した例：
+
+- `IdeasController#show`で`StoryEvent`の`story`関連付けにincludesが
+  抜けており、イベント一覧表示時にN+1クエリが発生していた
+  → `.includes(:story)`を追加して解消
 
 ## 外部サービス
 

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -22,7 +22,7 @@ class IdeasController < ApplicationController
     @stories = current_user.stories.order(created_at: :desc)
     story_ids = @stories.pluck(:id)
 
-    @story_events = StoryEvent.where(story_id: story_ids).order(created_at: :desc)
+    @story_events = StoryEvent.includes(:story).where(story_id: story_ids).order(created_at: :desc)
     @story_elements = StoryElement.includes(:story).where(story_id: story_ids).to_a
     @story_event_ideas = StoryEventIdea.includes(story_event: :story)
                                        .joins(story_event: :story)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/integer/time"
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -68,4 +69,13 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
+  # N+1クエリなどを検出して知らせてくれる(開発環境のみ・本番には影響しない)
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.rails_logger = true
+    Bullet.console = true
+    Bullet.add_footer = true
+  end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
- development環境のみにbullet gemを追加(本番・テストには影響なし)
- IdeasController#showでStoryEventのstory関連付けにincludesが 抜けており、イベントタブ表示時にN+1クエリが発生していたのを Bulletで検出し、.includes(:story)を追加して解消
- READMEに使用技術としてBulletを追記し、実際に検出・対応した例を記載

N+1クエリ対策の明示: IdeasController#showで複数のクエリを発行していますが、includesが一部不足している箇所があります。Bullet gemを導入して検出・対策し、READMEに「N+1対策済み」と書けるとアピール力が上がります！　を改善