### PR TITLE
Feature/search kana normalize and suggest memo

### DIFF
--- a/app/javascript/controllers/search_autocomplete_controller.js
+++ b/app/javascript/controllers/search_autocomplete_controller.js
@@ -76,16 +76,17 @@ export default class extends Controller {
   }
 
   render(data) {
-    // data例: {home:["..."], story:["..."], event:["..."], element:["..."]}
+    // data例: {home:[{title:"...", matched_by_memo:false}, ...], story:[...], event:[...], element:[...], story_event_idea:[...]}
     const items = []
     ;[
       ["home", "ホーム未所属"],
       ["story", "ストーリー内"],
       ["event", "イベント内"],
-      ["element", "要素内"]
+      ["element", "要素内"],
+      ["story_event_idea", "詳細メモ内"]
     ].forEach(([key, label]) => {
-      ;(data[key] || []).forEach((title) => {
-        items.push({ title, label })
+      ;(data[key] || []).forEach((entry) => {
+        items.push({ title: entry.title, label, matchedByMemo: !!entry.matched_by_memo })
       })
     })
 
@@ -96,12 +97,13 @@ export default class extends Controller {
 
     const html = items
       .slice(0, 20)
-      .map(
-        (it) =>
-          `<li data-action="mousedown->search-autocomplete#pick" data-title="${this.escape(
-            it.title
-          )}">${this.escape(it.title)} <small>(${this.escape(it.label)})</small></li>`
-      )
+      .map((it) => {
+        // タイトル自体には検索ワードが含まれず、メモの中身だけで見つかった場合の注記
+        const memoNote = it.matchedByMemo ? "・メモ内でヒット" : ""
+        return `<li data-action="mousedown->search-autocomplete#pick" data-title="${this.escape(
+          it.title
+        )}">${this.escape(it.title)} <small>(${this.escape(it.label)}${memoNote})</small></li>`
+      })
       .join("")
 
     this.listTarget.innerHTML = html

--- a/app/javascript/controllers/search_autocomplete_controller.js
+++ b/app/javascript/controllers/search_autocomplete_controller.js
@@ -102,7 +102,7 @@ export default class extends Controller {
         const memoNote = it.matchedByMemo ? "・メモ内でヒット" : ""
         return `<li data-action="mousedown->search-autocomplete#pick" data-title="${this.escape(
           it.title
-        )}">${this.escape(it.title)} <small>(${this.escape(it.label)}${memoNote})</small></li>`
+        )}" data-matched-by-memo="${it.matchedByMemo}">${this.escape(it.title)} <small>(${this.escape(it.label)}${memoNote})</small></li>`
       })
       .join("")
 
@@ -116,10 +116,20 @@ export default class extends Controller {
   }
 
   pick(e) {
-    const title = e.currentTarget.dataset.title
-    this.inputTarget.value = title
+    const matchedByMemo = e.currentTarget.dataset.matchedByMemo === "true"
+
+    // メモ内でヒットした候補は、タイトルが元の入力ワードと無関係なことがあるため、
+    // 検索欄は書き換えず、入力していた言葉のまま検索する
+    // (タイトルに書き換えると、同じタイトルを持つ無関係なアイデアまで一緒に出てきてしまうため)
+    if (!matchedByMemo) {
+      const title = e.currentTarget.dataset.title
+      this.inputTarget.value = title
+    }
+
     this.renderEmpty()
-    // Enter検索はユーザーが検索ボタン/Enterで実行する（壊さない）
+    // 候補をクリックしたら、そのまま検索まで実行する
+    // (this.elementは検索フォーム自体。Enter検索/検索ボタンと同じ経路で送信する)
+    this.element.requestSubmit()
   }
 
   escape(str) {

--- a/app/services/search/suggestions.rb
+++ b/app/services/search/suggestions.rb
@@ -14,8 +14,9 @@ module Search
     end
     # rubocop:enable Naming/MethodParameterName
 
-    # 候補は title のみ
-    # 返り値: { home: [...], story: [...], event: [...], element: [...], story_event_idea: [...] }
+    # 検索対象はタイトル・メモ両方。候補として画面に出す文字列自体は title のみ
+    # 返り値: { home: [{ title:, matched_by_memo: }, ...], story: [...], ... }
+    # matched_by_memo は、タイトル自体は一致せず、メモの中身だけで見つかった場合に true
     # scopeが特定なら、そのカテゴリだけ返す
     def call
       return {} if @q.blank?
@@ -50,9 +51,11 @@ module Search
       Idea.where(user_id: @user.id)
     end
 
-    def apply_title_search(rel)
+    # タイトルだけでなくメモの中身も検索対象にする。
+    # 候補として画面に出す文字列自体は、あくまでタイトル(select_titles参照)。
+    def apply_text_search(rel)
       like = "%#{ActiveRecord::Base.sanitize_sql_like(@q)}%"
-      rel.where("ideas.title LIKE :q", q: like)
+      rel.where("ideas.title LIKE :q OR ideas.memo LIKE :q", q: like)
     end
 
     def apply_story_element_filter(rel)
@@ -64,10 +67,32 @@ module Search
     end
 
     def select_titles(rel)
-      rel.group("ideas.title")
-         .order(Arel.sql("MAX(ideas.created_at) DESC"))
-         .limit(LIMIT)
-         .pluck("ideas.title")
+      titles =
+        rel.group("ideas.title")
+           .order(Arel.sql("MAX(ideas.created_at) DESC"))
+           .limit(LIMIT)
+           .pluck("ideas.title")
+
+      return [] if titles.empty?
+
+      title_matched_set = titles_matching_query_itself(titles)
+
+      titles.map do |title|
+        { title: title, matched_by_memo: title_matched_set.exclude?(title) }
+      end
+    end
+
+    # 渡されたタイトル群のうち、タイトル自体にも検索ワードが含まれるものだけを返す。
+    # (これに含まれないタイトルは、メモの中身だけで見つかったということになる)
+    def titles_matching_query_itself(titles)
+      like = "%#{ActiveRecord::Base.sanitize_sql_like(@q)}%"
+
+      base_ideas
+        .where(title: titles)
+        .where("title LIKE :q", q: like)
+        .distinct
+        .pluck(:title)
+        .to_set
     end
 
     def build_home
@@ -75,7 +100,7 @@ module Search
       return [] if @story_element_id.present?
 
       rel =
-        apply_title_search(base_ideas)
+        apply_text_search(base_ideas)
         .where.missing(:idea_placement)
 
       select_titles(rel)
@@ -83,7 +108,7 @@ module Search
 
     def build_story
       rel =
-        apply_title_search(base_ideas)
+        apply_text_search(base_ideas)
         .joins(:idea_placement)
         .where(idea_placements: { placeable_type: "Story" })
 
@@ -94,7 +119,7 @@ module Search
 
     def build_event
       rel =
-        apply_title_search(base_ideas)
+        apply_text_search(base_ideas)
         .joins(:idea_placement)
         .where(idea_placements: { placeable_type: "StoryEvent" })
 
@@ -109,7 +134,7 @@ module Search
 
     def build_element
       rel =
-        apply_title_search(base_ideas)
+        apply_text_search(base_ideas)
         .joins(:idea_placement)
         .where(idea_placements: { placeable_type: "StoryElement" })
 
@@ -124,7 +149,7 @@ module Search
 
     def build_story_event_idea
       rel =
-        apply_title_search(base_ideas)
+        apply_text_search(base_ideas)
         .joins(:idea_placement)
         .where(idea_placements: { placeable_type: "StoryEventIdea" })
 

--- a/spec/services/search/query_spec.rb
+++ b/spec/services/search/query_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Search::Query, type: :service do
+  let(:user) { create(:user) }
+
+  # rubocop:disable Naming/MethodParameterName
+  def call(q:, scope: "all", story_id: nil, story_element_id: nil)
+    described_class.new(
+      q: q,
+      scope: scope,
+      story_id: story_id,
+      story_element_id: story_element_id,
+      user: user
+    ).call
+  end
+  # rubocop:enable Naming/MethodParameterName
+
+  describe "ホーム未所属アイデアの検索" do
+    it "タイトルの部分一致で見つかる" do
+      idea = create(:idea, user: user, title: "うさぎのアイデア", memo: "m")
+
+      result = call(q: "うさぎ", scope: "home")
+
+      expect(result[:home][:created_here]).to include(idea)
+    end
+
+    it "メモの部分一致でも見つかる（今まで通り）" do
+      idea = create(:idea, user: user, title: "t", memo: "うさぎが登場する")
+
+      result = call(q: "うさぎ", scope: "home")
+
+      expect(result[:home][:created_here]).to include(idea)
+    end
+
+    it "一致しない単語では見つからない" do
+      create(:idea, user: user, title: "うさぎのアイデア", memo: "m")
+
+      result = call(q: "きりん", scope: "home")
+
+      expect(result[:home][:created_here]).to be_empty
+    end
+  end
+
+  describe "ひらがな/カタカナの表記ゆれ" do
+    it "ひらがなで検索して、カタカナ表記のタイトルも見つかる" do
+      idea = create(:idea, user: user, title: "ウサギのアイデア", memo: "m")
+
+      result = call(q: "うさぎ", scope: "home")
+
+      expect(result[:home][:created_here]).to include(idea)
+    end
+
+    it "カタカナで検索して、ひらがな表記のタイトルも見つかる" do
+      idea = create(:idea, user: user, title: "うさぎのアイデア", memo: "m")
+
+      result = call(q: "ウサギ", scope: "home")
+
+      expect(result[:home][:created_here]).to include(idea)
+    end
+  end
+end

--- a/spec/services/search/suggestions_spec.rb
+++ b/spec/services/search/suggestions_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Search::Suggestions, type: :service do
+  let(:user) { create(:user) }
+
+  # rubocop:disable Naming/MethodParameterName
+  def call(q:, scope: "all", story_id: nil, story_element_id: nil)
+    described_class.new(
+      q: q,
+      scope: scope,
+      story_id: story_id,
+      story_element_id: story_element_id,
+      user: user
+    ).call
+  end
+  # rubocop:enable Naming/MethodParameterName
+
+  describe "ホーム未所属アイデアのサジェスト" do
+    it "タイトルの部分一致で候補に出て、matched_by_memoはfalseになる" do
+      create(:idea, user: user, title: "うさぎのアイデア", memo: "m")
+
+      result = call(q: "うさぎ", scope: "home")
+
+      expect(result[:home]).to include(title: "うさぎのアイデア", matched_by_memo: false)
+    end
+
+    it "メモの部分一致でも、そのアイデアのタイトルが候補に出て、matched_by_memoはtrueになる" do
+      create(:idea, user: user, title: "森の物語", memo: "うさぎが登場する")
+
+      result = call(q: "うさぎ", scope: "home")
+
+      expect(result[:home]).to include(title: "森の物語", matched_by_memo: true)
+    end
+
+    it "タイトル・メモ両方に一致する場合は、matched_by_memoはfalseになる（タイトルからも分かるため）" do
+      create(:idea, user: user, title: "うさぎの物語", memo: "うさぎが登場する")
+
+      result = call(q: "うさぎ", scope: "home")
+
+      expect(result[:home]).to include(title: "うさぎの物語", matched_by_memo: false)
+    end
+  end
+
+  describe "ひらがな/カタカナの表記ゆれ" do
+    it "ひらがなで検索して、カタカナ表記のタイトルも候補に出る" do
+      create(:idea, user: user, title: "ウサギのアイデア", memo: "m")
+
+      result = call(q: "うさぎ", scope: "home")
+
+      expect(result[:home]).to include(title: "ウサギのアイデア", matched_by_memo: false)
+    end
+  end
+end


### PR DESCRIPTION
概要

検索のサジェスト（候補表示）機能を改善しました。検索対象をタイトルだけでなくメモの中身にも広げ、候補をクリックしたら検索まで自動実行されるようにしています。あわせて、調査の過程で見つかった既存の表示バグも修正しています。

変更内容
サジェストの検索対象をメモにも拡大
Search::Suggestionsの検索対象を、タイトルのみから「タイトル＋メモ」に拡大（Search::Queryの本検索と同じ範囲に統一）
タイトル自体には一致せず、メモの中身だけで見つかった候補には「メモ内でヒット」と表示し、なぜその候補が出てきたか分かるようにした
既存バグの修正（詳細メモ内のサジェストが表示されない）

調査の過程で、search_autocomplete_controller.jsが「詳細メモ内」（story_event_idea）のサジェスト結果を描画対象に含めておらず、バックエンドは正しく返しているのに画面には一切表示されない既存バグを発見し、あわせて修正しました。

候補クリックで検索まで自動実行
今までは候補をクリックしても検索欄に文字が入るだけで、検索はEnterキー/検索ボタン待ちだった
クリックしたらそのまま検索結果まで遷移するように変更
ただし、メモの中身だけで一致した候補は、タイトルが元の入力ワードと無関係なことがあるため、クリックしても検索欄は書き換えず、入力していた言葉のまま検索するようにした（タイトルに書き換えると、同じタイトルを持つ無関係なアイデアまで一緒に出てきてしまう問題があったため）
ひらがな/カタカナの表記ゆれについて

調査の結果、MySQLの照合順序（utf8mb4_0900_ai_ci）で既に吸収されていることが判明したため、コード変更は不要と判断し、裏付けとなるテストのみ追加しています。

確認内容
RSpec：87 examples, 0 failures（Search::Query・Search::Suggestionsのサービス単体テストを新規作成）
RuboCop：141ファイル offenseなし
ブラウザで実際に、全5カテゴリ（ホーム未所属/ストーリー内/イベント内/要素内/詳細メモ内）でのサジェスト表示、候補クリックからの自動検索、メモ一致時の絞り込み精度、通常検索（候補を使わない）を確認済み
本検索のロジック（Search::Query、SearchController）は変更していません