### PR TITLE
AI生成のOpenAI API呼び出しに、一時的な失敗のリトライ処理を追加

### DIFF
--- a/app/services/ai/idea_generator.rb
+++ b/app/services/ai/idea_generator.rb
@@ -7,11 +7,25 @@ module Ai
   class IdeaGenerator
     ENDPOINT = "https://api.openai.com/v1/responses"
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # 一時的な失敗(通信エラー・タイムアウト・429/5xx)だけ、間隔を空けて
+    # 合計MAX_ATTEMPTS回まで試行する。認証エラーなど何度やっても直らない
+    # 失敗(401など)はリトライせず、すぐに諦める。
+    MAX_ATTEMPTS = 3
+    RETRY_WAIT_SECONDS = 1
+
     def self.call(word1:, word2:, word1_pos:, word2_pos:)
       raise "OPENAI_API_KEY is missing" if ENV["OPENAI_API_KEY"].to_s.strip.empty?
 
-      prompt = <<~TEXT
+      prompt = build_prompt(word1: word1, word2: word2, word1_pos: word1_pos, word2_pos: word2_pos)
+      res = request_with_retry(prompt)
+
+      raise "OpenAI error: #{res.status} #{res.body}" unless res.success?
+
+      extract_text(res.body)
+    end
+
+    def self.build_prompt(word1:, word2:, word1_pos:, word2_pos:)
+      <<~TEXT
         次の2語を必ず使って、物語のタネになる短いアイデア文を日本語で作ってください。
         ・2〜4文
         ・説明は不要
@@ -20,13 +34,17 @@ module Ai
         1) #{word1}（#{part_of_speech_label(word1_pos)}）
         2) #{word2}（#{part_of_speech_label(word2_pos)}）
       TEXT
+    end
 
-      conn = Faraday.new do |f|
+    def self.connection
+      Faraday.new do |f|
         f.request :json
         f.response :json
       end
+    end
 
-      res = conn.post(ENDPOINT) do |req|
+    def self.post_request(conn, prompt)
+      conn.post(ENDPOINT) do |req|
         req.headers["Authorization"] = "Bearer #{ENV['OPENAI_API_KEY']}"
         req.headers["Content-Type"] = "application/json"
         req.body = {
@@ -35,12 +53,35 @@ module Ai
           store: false
         }
       end
-
-      raise "OpenAI error: #{res.status} #{res.body}" unless res.success?
-
-      extract_text(res.body)
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def self.request_with_retry(prompt)
+      conn = connection
+      last_response = nil
+      last_error = nil
+
+      MAX_ATTEMPTS.times do |attempt|
+        begin
+          last_response = post_request(conn, prompt)
+          return last_response if last_response.success? || !retryable_status?(last_response.status)
+
+          last_error = nil
+        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+          last_error = e
+          last_response = nil
+        end
+
+        sleep(RETRY_WAIT_SECONDS) if attempt < MAX_ATTEMPTS - 1
+      end
+
+      raise last_error if last_error
+
+      last_response
+    end
+
+    def self.retryable_status?(status)
+      status == 429 || (500..599).cover?(status)
+    end
 
     def self.extract_text(body)
       output = body["output"] || []
@@ -60,6 +101,7 @@ module Ai
       value.to_s == "verb" ? "動詞" : "名詞"
     end
 
-    private_class_method :extract_text, :part_of_speech_label
+    private_class_method :build_prompt, :connection, :post_request, :request_with_retry,
+                         :retryable_status?, :extract_text, :part_of_speech_label
   end
 end

--- a/spec/services/ai/idea_generator_spec.rb
+++ b/spec/services/ai/idea_generator_spec.rb
@@ -1,0 +1,73 @@
+# rubocop:disable RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe Ai::IdeaGenerator, type: :service do
+  # OpenAIへ本物の通信をしないように、Faraday標準のテスト用アダプタで差し替える。
+  # statuses に並べた順番で、リクエストのたびに違うレスポンスを返す。
+  def stub_connection(statuses)
+    call_count = 0
+
+    Faraday.new do |f|
+      f.request :json
+      f.response :json
+      f.adapter :test do |stub|
+        stub.post("https://api.openai.com/v1/responses") do |_env|
+          status = statuses[call_count]
+          call_count += 1
+
+          body =
+            if status == 200
+              { output: [{ type: "message", content: [{ type: "output_text", text: "生成結果" }] }] }
+            else
+              { error: "dummy" }
+            end
+
+          [status, { "Content-Type" => "application/json" }, body.to_json]
+        end
+      end
+    end
+  end
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("OPENAI_API_KEY").and_return("test-key")
+    allow(described_class).to receive(:sleep) # テストを遅くしないためリトライ待機を無効化
+  end
+
+  def call_generator
+    described_class.call(word1: "うさぎ", word2: "走る", word1_pos: "noun", word2_pos: "verb")
+  end
+
+  it "1回で成功する場合、そのままリトライせずに結果を返す" do
+    conn = stub_connection([200])
+    allow(described_class).to receive(:connection).and_return(conn)
+
+    expect(call_generator).to eq("生成結果")
+    expect(described_class).not_to have_received(:sleep)
+  end
+
+  it "一時的な失敗(500)の後に成功すれば、リトライして結果を返す" do
+    conn = stub_connection([500, 200])
+    allow(described_class).to receive(:connection).and_return(conn)
+
+    expect(call_generator).to eq("生成結果")
+    expect(described_class).to have_received(:sleep).once
+  end
+
+  it "認証エラー(401)などは回復しないので、リトライせずすぐに例外を投げる" do
+    conn = stub_connection([401])
+    allow(described_class).to receive(:connection).and_return(conn)
+
+    expect { call_generator }.to raise_error(/OpenAI error: 401/)
+    expect(described_class).not_to have_received(:sleep)
+  end
+
+  it "5xxが上限まで続く場合は、リトライした上で最終的に例外を投げる" do
+    conn = stub_connection([500, 500, 500])
+    allow(described_class).to receive(:connection).and_return(conn)
+
+    expect { call_generator }.to raise_error(/OpenAI error: 500/)
+    expect(described_class).to have_received(:sleep).twice
+  end
+end
+# rubocop:enable RSpec/MultipleExpectations


### PR DESCRIPTION
- 通信部分をconnection/post_requestメソッドに切り出し (Faradayのテスト用アダプタで模擬通信できるようにするため。 動作自体は変えていない)
- request_with_retryを追加し、一時的な失敗(429・5xx・通信エラー・ タイムアウト)だけ最大3回まで、1秒間隔でリトライするようにした
- 認証エラー(401)など何度やっても直らない失敗は、今まで通り リトライせず即座に例外を投げる
- spec/services/ai/idea_generator_spec.rbを新規作成し、 「1回で成功」「リトライ後に成功」「回復しない失敗は即諦める」 「リトライ上限まで失敗し続ける」の4パターンを確認
- 本番相当のOpenAI APIを実際に呼び出し、正常系が壊れていないことを ブラウザで確認済み