### PR TITLE
Feature/story element add kinds

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,9 @@ module ApplicationHelper
     {
       "character" => "キャラクター",
       "item" => "アイテム",
-      "setting" => "設定"
+      "setting" => "設定",
+      "place" => "場所",
+      "organization" => "団体・グループ"
     }[element.kind.to_s] || element.kind.to_s.presence
   end
 end

--- a/app/javascript/controllers/element_selector_controller.js
+++ b/app/javascript/controllers/element_selector_controller.js
@@ -36,7 +36,9 @@ export default class extends Controller {
     const selectedByKind = {
       character: [],
       item: [],
-      setting: []
+      setting: [],
+      place: [],
+      organization: []
     }
 
     this.checkboxTargets.forEach((checkbox) => {
@@ -93,7 +95,9 @@ export default class extends Controller {
     return {
       character: "キャラクター",
       item: "アイテム",
-      setting: "設定"
+      setting: "設定",
+      place: "場所",
+      organization: "団体・グループ"
     }[kind] || kind
   }
 

--- a/app/models/story_element.rb
+++ b/app/models/story_element.rb
@@ -17,14 +17,14 @@ class StoryElement < ApplicationRecord
 
   accepts_nested_attributes_for :story_element_image, allow_destroy: true
 
-  enum :kind, { character: 0, item: 1, setting: 2 }
+  enum :kind, { character: 0, item: 1, setting: 2, place: 3, organization: 4 }
 
   validates :kind, presence: true
   validates :name, presence: true
 
   before_save :set_text_updated_at, if: :should_update_text_updated_at?
 
-  KIND_ORDER = { "character" => 0, "item" => 1, "setting" => 2 }.freeze
+  KIND_ORDER = { "character" => 0, "item" => 1, "setting" => 2, "place" => 3, "organization" => 4 }.freeze
 
   def self.sorted_by_kind_and_name(elements = all)
     elements.sort_by(&:kind_and_name_sort_key)

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -99,7 +99,9 @@
 
             <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
             <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
-            <div data-element-selector-target="summary" data-kind="setting" hidden style="color: #ffffff;"></div>
+            <div data-element-selector-target="summary" data-kind="setting" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+            <div data-element-selector-target="summary" data-kind="place" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+            <div data-element-selector-target="summary" data-kind="organization" hidden style="color: #ffffff;"></div>
           </div>
 
           <div style="margin-top: 16px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
@@ -107,7 +109,7 @@
               要素を選択する
             </div>
 
-            <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+            <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"], ["place", "場所"], ["organization", "団体・グループ"]].each do |kind, kind_label| %>
               <% elements = grouped_elements[kind] || [] %>
               <% next if elements.blank? %>
 

--- a/app/views/ideas/show.html.erb
+++ b/app/views/ideas/show.html.erb
@@ -248,7 +248,7 @@
     <strong>登場要素：</strong>
 
     <div style="margin-top: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e;">
-      <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+      <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"], ["place", "場所"], ["organization", "団体・グループ"]].each do |kind, kind_label| %>
         <% kind_elements = grouped_elements[kind] || [] %>
         <% next if kind_elements.blank? %>
 
@@ -317,8 +317,8 @@
   <hr>
   <h2 style="color: #c4b5fd;">移動先の要素を選ぶ（文字順）</h2>
 
-  <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定" } %>
-  <% kind_order = { "character" => 0, "item" => 1, "setting" => 2 } %>
+  <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定", "place" => "場所", "organization" => "団体" } %>
+  <% kind_order = { "character" => 0, "item" => 1, "setting" => 2, "place" => 3, "organization" => 4 } %>
   <% element_display_label = lambda do |el|
        kind_label = kind_labels[el.kind] || el.kind
        marker_text = el.marker.to_s

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -26,7 +26,7 @@
   <li>
     要素：
     <% if @selected_story_element.present? %>
-      <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定" } %>
+      <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定", "place" => "場所", "organization" => "団体" } %>
       [<%= kind_labels[@selected_story_element.kind.to_s] || @selected_story_element.kind %>]<%= @selected_story_element.marker %>　<%= @selected_story_element.name %>
     <% else %>
       （なし）

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -338,8 +338,8 @@
       <% end %>
 
       <% if header_story.present? && allow_within_story_toggle %>
-        <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定" } %>
-        <% kind_order = { "character" => 0, "item" => 1, "setting" => 2 } %>
+        <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定", "place" => "場所", "organization" => "団体" } %>
+        <% kind_order = { "character" => 0, "item" => 1, "setting" => 2, "place" => 3, "organization" => 4 } %>
 
         <% story_element_options =
              [["（要素で絞り込み：なし）", ""]] +

--- a/app/views/stories/consistency.html.erb
+++ b/app/views/stories/consistency.html.erb
@@ -47,6 +47,10 @@
               "アイテム"
             when "setting"
               "設定"
+            when "place"
+              "場所"
+            when "organization"
+              "団体"
             else
               e.kind
             end
@@ -77,6 +81,10 @@
          "アイテム"
        when "setting"
          "設定"
+       when "place"
+         "場所"
+       when "organization"
+         "団体"
        else
          @selected_element.kind
        end %>

--- a/app/views/story_elements/_form.html.erb
+++ b/app/views/story_elements/_form.html.erb
@@ -12,7 +12,7 @@
   <div style="margin-bottom: 20px;">
     <%= f.label :kind, "分類", style: "font-size: 24px; font-weight: bold; color: #ddd6fe;" %><br>
     <%= f.select :kind,
-                 [["キャラクター", "character"], ["アイテム", "item"], ["設定", "setting"]],
+                 [["キャラクター", "character"], ["アイテム", "item"], ["設定", "setting"], ["場所", "place"], ["団体・グループ", "organization"]],
                  { include_blank: true },
                  { style: "width: 100%; max-width: 220px; box-sizing: border-box;" } %>
   </div>

--- a/app/views/story_elements/index.html.erb
+++ b/app/views/story_elements/index.html.erb
@@ -42,7 +42,9 @@
 <% [
   ["character", "キャラクター"],
   ["item", "アイテム"],
-  ["setting", "設定"]
+  ["setting", "設定"],
+  ["place", "場所"],
+  ["organization", "団体・グループ"]
 ].each do |kind, title| %>
   <% next if grouped_elements[kind].blank? %>
 

--- a/app/views/story_elements/show.html.erb
+++ b/app/views/story_elements/show.html.erb
@@ -16,7 +16,7 @@
 <hr>
 
 <p style="font-size: 32px; font-weight: bold; margin: 0 0 16px 0; color: #ddd6fe;"><strong>名前：</strong><%= @story_element.name %></p>
-<p style="color: #ddd6fe;"><strong>分類：</strong><%= { "character" => "キャラクター", "item" => "アイテム", "setting" => "設定" }[@story_element.kind] || @story_element.kind %></p>
+<p style="color: #ddd6fe;"><strong>分類：</strong><%= { "character" => "キャラクター", "item" => "アイテム", "setting" => "設定", "place" => "場所", "organization" => "団体・グループ" }[@story_element.kind] || @story_element.kind %></p>
 <p style="color: #ddd6fe;"><strong>マーカー：</strong><%= @story_element.marker.presence || "なし" %></p>
 
 <% if @story_element.story_element_image&.image? %>

--- a/app/views/story_event_ideas/_form.html.erb
+++ b/app/views/story_event_ideas/_form.html.erb
@@ -71,7 +71,9 @@
 
         <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
         <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
-        <div data-element-selector-target="summary" data-kind="setting" hidden style="color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="setting" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="place" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="organization" hidden style="color: #ffffff;"></div>
       </div>
 
       <div style="margin-top: 16px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
@@ -79,7 +81,7 @@
           要素を選択する
         </div>
 
-        <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+        <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"], ["place", "場所"], ["organization", "団体・グループ"]].each do |kind, kind_label| %>
           <% elements = grouped_elements[kind] || [] %>
           <% next if elements.blank? %>
 

--- a/app/views/story_event_ideas/show.html.erb
+++ b/app/views/story_event_ideas/show.html.erb
@@ -70,7 +70,7 @@
   <% grouped_elements = StoryElement.sorted_by_kind_and_name(@story_event_idea.story_elements).group_by(&:kind) %>
 
   <div style="margin-top: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e;">
-    <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+    <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"], ["place", "場所"], ["organization", "団体・グループ"]].each do |kind, kind_label| %>
       <% elements = grouped_elements[kind] || [] %>
       <% next if elements.blank? %>
 

--- a/app/views/story_events/_form.html.erb
+++ b/app/views/story_events/_form.html.erb
@@ -76,7 +76,9 @@
 
         <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
         <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
-        <div data-element-selector-target="summary" data-kind="setting" hidden style="color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="setting" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="place" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="organization" hidden style="color: #ffffff;"></div>
       </div>
 
       <div style="margin-top: 16px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
@@ -84,7 +86,7 @@
           要素を選択する
         </div>
 
-        <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+        <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"], ["place", "場所"], ["organization", "団体・グループ"]].each do |kind, kind_label| %>
           <% elements = grouped_elements[kind] || [] %>
           <% next if elements.blank? %>
 

--- a/app/views/story_events/show.html.erb
+++ b/app/views/story_events/show.html.erb
@@ -31,7 +31,7 @@
   <% grouped_elements = StoryElement.sorted_by_kind_and_name(@story_event.story_elements).group_by(&:kind) %>
 
   <div style="margin-top: 12px; margin-bottom: 24px; border: 1px solid #555555; border-radius: 16px; padding: 16px; background: #1e1e1e;">
-    <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"]].each do |kind, kind_label| %>
+    <% [["character", "キャラクター"], ["item", "アイテム"], ["setting", "設定"], ["place", "場所"], ["organization", "団体・グループ"]].each do |kind, kind_label| %>
       <% elements = grouped_elements[kind] || [] %>
       <% next if elements.blank? %>
 


### PR DESCRIPTION
## 概要

要素の種類（分類）に「場所」「団体・グループ」の2つを追加しました。
これまでの3種類（キャラクター/アイテム/設定）に加え、計5種類になります。

## 変更内容

- `StoryElement#kind` の enum に `place`（場所）/ `organization`（団体・グループ）を追加
  - `KIND_ORDER` にも表示順を追加
  - enumキーを `group` ではなく `organization` にしています。`group` は ActiveRecord の `.group`（GROUP BY用メソッド）と名前が衝突し、実際に起動時エラーになることを確認したためです
- 要素管理（作成/編集フォーム・一覧・詳細）に新しい種類のラベル・グループ表示を追加
- イベント作成/編集、詳細メモ作成/編集の要素紐付けUI（チェックボックスのグループ表示・JS集計）に追加
- アイデア（ホーム以外）の要素紐付け表示・移動先要素一覧に追加
- 整合性チェックの要素選択プルダウン・選択中要素ラベルに追加
- 検索結果、ヘッダーの「要素で絞り込み」プルダウンに追加

コミットは機能単位で分割しています（モデル→要素管理→イベント/詳細メモ→アイデア→整合性チェック→検索/ヘッダー）。

## 検証内容

- 既存の rspec 全件（91件）パス、RuboCop offenseなし
- ブラウザで実際に「場所」「団体・グループ」の要素を作成し、以下を目視確認
  - 要素一覧・詳細での分類表示
  - イベント/詳細メモ作成フォームでのチェックボックスグループ表示、選択時のJSサマリー表示
  - イベント/詳細メモ/アイデア詳細での登場要素グループ表示
  - 整合性チェックで実際に紐付いたイベント・詳細メモが時系列表示されること
  - 検索結果・ヘッダー絞り込みプルダウンでのラベル表示
- 既存の3種類（キャラクター/アイテム/設定）の表示・動作に影響がないことを確認
- 検証用に作成したテストユーザー・データは確認後に削除済み

## 備考（今回のスコープ外）

検証中に、`app/views/shared/_header.html.erb` のインラインスクリプト（`setupSearchHeader`）が、同一タブでの複数回のTurbo遷移で `Identifier 'setupSearchHeader' has already been declared` というJSエラーを起こす既存バグを見つけました。今回の変更とは無関係（このファイルで触ったのはラベル配列のみ）のため、本PRには含めていません。