### PR TITLE
Feature/search multi element filter

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -93,6 +93,7 @@ class SearchController < ApplicationController
   def assign_story_element_for_index
     raw_story_element_id = params[:story_element_id].presence&.to_i
 
+    # ヘッダーで選ばれた1個（従来通りの単一選択）
     @story_element_id =
       sanitize_story_element_id(
         story: @story,
@@ -100,9 +101,26 @@ class SearchController < ApplicationController
         story_element_id: raw_story_element_id
       )
 
-    return unless @story.present? && @story_element_id.present?
+    # 検索結果ページ内の「要素で絞り込む」欄で選んだ複数の要素
+    # （まだ選び直していない場合は、ヘッダーで選んだ1個をそのまま引き継ぐ）
+    @selected_story_element_ids = resolve_selected_story_element_ids
+    @selected_story_elements =
+      @story.present? ? @story.story_elements.where(id: @selected_story_element_ids) : StoryElement.none
+  end
 
-    @selected_story_element = @story.story_elements.find_by(id: @story_element_id)
+  def resolve_selected_story_element_ids
+    return [] unless @within_story && @story.present?
+
+    raw_selected_story_element_ids.select { |id| @story.story_elements.exists?(id: id) }.uniq
+  end
+
+  # 検索結果ページの絞り込みフォームが一度でも送信されていればそちらを優先し、
+  # まだなら（検索前や、ヘッダーから来た直後）ヘッダーで選んだ1個をそのまま使う
+  def raw_selected_story_element_ids
+    return Array(params[:search_story_element_ids]).map(&:to_i).reject(&:zero?) if params.key?(:search_story_element_ids)
+    return [@story_element_id] if @story_element_id.present?
+
+    []
   end
 
   def assign_page_context_for_index
@@ -146,16 +164,16 @@ class SearchController < ApplicationController
   end
 
   def perform_search
-    return {} if @query.blank? && @story_element_id.blank?
+    return {} if @query.blank? && @selected_story_element_ids.blank?
 
     service_story_id = @within_story ? @story_id : nil
-    service_story_element_id = @within_story ? @story_element_id : nil
+    service_story_element_ids = @within_story ? @selected_story_element_ids : []
 
     Search::Query.new(
       q: @query,
       scope: @scope,
       story_id: service_story_id,
-      story_element_id: service_story_element_id,
+      story_element_ids: service_story_element_ids,
       user: current_user
     ).call
   end

--- a/app/javascript/controllers/element_selector_controller.js
+++ b/app/javascript/controllers/element_selector_controller.js
@@ -67,7 +67,7 @@ export default class extends Controller {
           ${this.kindLabel(kind)}（${items.length}）
         </div>
         <div style="display: flex; flex-wrap: wrap; gap: 8px;">
-          ${items.map((item) => this.badgeHtml(item.label)).join("")}
+          ${items.map((item) => this.badgeHtml(item)).join("")}
         </div>
       `
     })
@@ -83,12 +83,26 @@ export default class extends Controller {
     }
   }
 
-  badgeHtml(label) {
+  // タグ自体を押すと、対応するチェックボックスのチェックを外して選択解除する
+  badgeHtml(item) {
     return `
-      <span style="display: inline-block; padding: 6px 10px; border: 1px solid #ccc; border-radius: 9999px;">
-        ${this.escapeHtml(label)}
+      <span data-action="click->element-selector#remove"
+            data-id="${this.escapeHtml(item.id)}"
+            title="クリックで選択解除"
+            style="display: inline-flex; align-items: center; gap: 4px; padding: 6px 10px; border: 1px solid #ccc; border-radius: 9999px; cursor: pointer;">
+        ${this.escapeHtml(item.label)}
+        <span aria-hidden="true">×</span>
       </span>
     `
+  }
+
+  remove(event) {
+    const id = event.currentTarget.dataset.id
+    const checkbox = this.checkboxTargets.find((element) => element.value === id)
+    if (!checkbox) return
+
+    checkbox.checked = false
+    this.refresh()
   }
 
   kindLabel(kind) {

--- a/app/javascript/controllers/element_selector_controller.js
+++ b/app/javascript/controllers/element_selector_controller.js
@@ -91,7 +91,7 @@ export default class extends Controller {
             title="クリックで選択解除"
             style="display: inline-flex; align-items: center; gap: 4px; padding: 6px 10px; border: 1px solid #ccc; border-radius: 9999px; cursor: pointer;">
         ${this.escapeHtml(item.label)}
-        <span aria-hidden="true">×</span>
+        <span aria-hidden="true" style="color: #f87171; font-weight: bold;">×</span>
       </span>
     `
   }

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -4,17 +4,17 @@ module Search
     VALID_SCOPES = %w[all home story event element story_event_idea].freeze
 
     # rubocop:disable Naming/MethodParameterName
-    def initialize(q:, scope:, story_id:, story_element_id:, user:)
-      @q                = q.to_s.strip
-      @scope            = normalize_scope(scope)
-      @story_id         = story_id.presence&.to_i
-      @story_element_id = story_element_id.presence&.to_i
-      @user             = user
+    def initialize(q:, scope:, story_id:, story_element_ids:, user:)
+      @q                 = q.to_s.strip
+      @scope             = normalize_scope(scope)
+      @story_id          = story_id.presence&.to_i
+      @story_element_ids = Array(story_element_ids).map(&:to_i).reject(&:zero?).uniq
+      @user              = user
     end
     # rubocop:enable Naming/MethodParameterName
 
     def call
-      return {} if @q.blank? && @story_element_id.blank?
+      return {} if @q.blank? && @story_element_ids.blank?
 
       case @scope
       when "home"             then { home: build_home }
@@ -60,16 +60,21 @@ module Search
       }
     end
 
+    # 選んだ要素が全部そろって紐づいているアイデアだけに絞り込む（AND条件）。
+    # GROUP BY + HAVINGで絞り込んだ後にcreated_hereでの分岐・並び替えを続けても
+    # 崩れないことは確認済み（idsが1個の場合は今までと同じ結果になる）
     def apply_story_element_filter(rel)
-      return rel if @story_element_id.blank?
+      return rel if @story_element_ids.blank?
 
       rel.joins(idea_placement: :idea_placement_elements)
-         .where(idea_placement_elements: { story_element_id: @story_element_id })
+         .where(idea_placement_elements: { story_element_id: @story_element_ids })
+         .group("ideas.id")
+         .having("COUNT(DISTINCT idea_placement_elements.story_element_id) = ?", @story_element_ids.size)
     end
 
     def build_home
       return empty_pair if @story_id.present?
-      return empty_pair if @story_element_id.present?
+      return empty_pair if @story_element_ids.present?
 
       rel =
         apply_text_search(base_ideas)

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -89,9 +89,12 @@
           <%= hidden_field_tag "idea[idea_placement_attributes][story_element_ids][]", "" %>
 
           <div style="margin-top: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
-            <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px; color: #ddd6fe;">
+            <div style="font-size: 20px; font-weight: bold; margin-bottom: 4px; color: #ddd6fe;">
               選択中の要素
             </div>
+            <p style="margin: 0 0 12px 0; font-size: 14px; color: #cccccc;">
+              ×を押すと、その要素の選択を解除できます。
+            </p>
 
             <p data-element-selector-target="emptyMessage" style="margin: 0; color: #cccccc;">
               まだ選択されていません

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -61,9 +61,12 @@
 
       <%# チェックした瞬間、押す前でもここに選んだ要素がタグで表示される %>
       <div style="margin-bottom: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff; max-width: 420px;">
-        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px; color: #ddd6fe;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 4px; color: #ddd6fe;">
           選択中の要素
         </div>
+        <p style="margin: 0 0 12px 0; font-size: 14px; color: #cccccc;">
+          ×を押すと、その要素の選択を解除できます。
+        </p>
 
         <p data-element-selector-target="emptyMessage" style="margin: 0; color: #cccccc;">
           まだ選択されていません

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -25,21 +25,95 @@
 
   <li>
     要素：
-    <% if @selected_story_element.present? %>
-      <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定", "place" => "場所", "organization" => "団体" } %>
-      [<%= kind_labels[@selected_story_element.kind.to_s] || @selected_story_element.kind %>]<%= @selected_story_element.marker %>　<%= @selected_story_element.name %>
+    <% kind_labels = { "character" => "キャラ", "item" => "アイテム", "setting" => "設定", "place" => "場所", "organization" => "団体" } %>
+    <% if @selected_story_elements.present? %>
+      <% @selected_story_elements.each do |element| %>
+        [<%= kind_labels[element.kind.to_s] || element.kind %>]<%= element.marker %>　<%= element.name %><br>
+      <% end %>
     <% else %>
       （なし）
     <% end %>
   </li>
 </ul>
 
+<% if @within_story && @story.present? && @story.story_elements.any? %>
+  <div style="margin: 16px 0 24px 0;">
+    <div style="font-size: 20px; font-weight: bold; margin-bottom: 8px; color: #c4b5fd;">要素で絞り込む</div>
+    <p style="margin: 0 0 8px 0; font-size: 15px;">複数選ぶと、選んだ要素が全部そろって紐づいているアイデアだけに絞り込まれます。</p>
+
+    <%= form_with url: search_path, method: :get, local: true do %>
+      <%= hidden_field_tag :q, params[:q] if params[:q].present? %>
+      <%= hidden_field_tag :scope, params[:scope] if params[:scope].present? %>
+      <%= hidden_field_tag :within_story, "1" %>
+      <%= hidden_field_tag :story_id, @story.id %>
+      <%= hidden_field_tag :from, params[:from] if params[:from].present? %>
+      <%= hidden_field_tag :story_event_id, params[:story_event_id] if params[:story_event_id].present? %>
+      <%= hidden_field_tag :story_event_idea_id, params[:story_event_idea_id] if params[:story_event_idea_id].present? %>
+      <%= hidden_field_tag :page_type, params[:page_type] if params[:page_type].present? %>
+      <%= hidden_field_tag :page_id, params[:page_id] if params[:page_id].present? %>
+      <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
+
+      <%# チェックを全部外した状態でも送信できるよう、キー自体を必ず残しておく隠しフィールド %>
+      <%= hidden_field_tag "search_story_element_ids[]", "" %>
+
+      <% grouped_elements = @story.story_elements.group_by(&:kind) %>
+
+      <div style="border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff; max-width: 420px;">
+        <%# 要素数が増えても縦に長くなりすぎないよう、分類ごとに開閉できるようにする %>
+        <% [
+          ["character", "キャラクター"],
+          ["item", "アイテム"],
+          ["setting", "設定"],
+          ["place", "場所"],
+          ["organization", "団体・グループ"]
+        ].each do |kind, kind_group_label| %>
+          <% elements_of_kind = grouped_elements[kind] || [] %>
+          <% next if elements_of_kind.blank? %>
+
+          <% any_selected_in_kind = elements_of_kind.any? { |el| @selected_story_element_ids.include?(el.id) } %>
+
+          <details style="margin-bottom: 12px;" <%= "open" if any_selected_in_kind %>>
+            <summary style="cursor: pointer; background: #2a2a2a; border: 1px solid #555555; border-radius: 6px; padding: 10px 12px; font-weight: bold; color: #f5f5f5;">
+              <%= kind_group_label %>（<%= elements_of_kind.size %>）
+            </summary>
+
+            <div style="padding: 12px 8px 0 8px;">
+              <% elements_of_kind.each do |element| %>
+                <div style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px; color: #ffffff;">
+                  <% checkbox_id = "search_story_element_ids_#{element.id}" %>
+
+                  <%= check_box_tag "search_story_element_ids[]",
+                        element.id,
+                        @selected_story_element_ids.include?(element.id),
+                        id: checkbox_id %>
+
+                  <label for="<%= checkbox_id %>" style="cursor: pointer; margin-bottom: 0; color: #ffffff;">
+                    <%= truncate("#{element.marker}　#{element.name}", length: 40) %>
+                  </label>
+                </div>
+              <% end %>
+            </div>
+          </details>
+        <% end %>
+      </div>
+
+      <div style="margin-top: 8px;">
+        <%= submit_tag "絞り込む",
+              style: "background: #2563eb; color: #ffffff; border: none; border-radius: 8px; padding: 10px 20px; font-weight: bold; cursor: pointer;" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
 <hr style="border: none; border-top: 1px solid #444444; margin: 20px 0;">
 
 <% results = (@results || {}).with_indifferent_access %>
 
-<% pair_total = ->(pair) { (pair[:created_here]&.count || 0) + (pair[:moved]&.count || 0) } %>
-<% home_total = ->(pair) { (pair[:created_here]&.count || 0) } %>
+<%# 要素を複数指定した検索結果はGROUP BYされているため、.countだと合計件数ではなく
+    グループごとの内訳(Hash)が返ってきてしまう。.to_a.sizeなら常に件数(Integer)になる %>
+<% record_count = ->(rel) { rel.nil? ? 0 : rel.to_a.size } %>
+<% pair_total = ->(pair) { record_count.call(pair[:created_here]) + record_count.call(pair[:moved]) } %>
+<% home_total = ->(pair) { record_count.call(pair[:created_here]) } %>
 
 <% snippet_for = lambda do |text, keyword|
      s = text.to_s
@@ -93,7 +167,7 @@
   <% end %>
 <% end %>
 
-<% if q.blank? && @story_element_id.blank? %>
+<% if q.blank? && @selected_story_element_ids.blank? %>
   <p>検索ワードを入力して検索してください。</p>
 <% else %>
   <h2 style="color: #c4b5fd;">件数</h2>
@@ -131,7 +205,7 @@
       <h1 style="color: #c4b5fd;"><%= title %></h1>
 
       <% if is_home %>
-        <% if created_rel.count == 0 %>
+        <% if created_rel.to_a.empty? %>
           <p>該当なし</p>
         <% else %>
           <div style="margin: 16px 0;">
@@ -142,7 +216,7 @@
         <% end %>
       <% else %>
         <h2 style="color: #c4b5fd;">新規作成したアイデア</h2>
-        <% if created_rel.count == 0 %>
+        <% if created_rel.to_a.empty? %>
           <p>該当なし</p>
         <% else %>
           <div style="margin: 16px 0;">
@@ -153,7 +227,7 @@
         <% end %>
 
         <h2 style="color: #c4b5fd;">移動してきたアイデア</h2>
-        <% if moved_rel.count == 0 %>
+        <% if moved_rel.to_a.empty? %>
           <p>該当なし</p>
         <% else %>
           <div style="margin: 16px 0;">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -41,7 +41,8 @@
     <div style="font-size: 20px; font-weight: bold; margin-bottom: 8px; color: #c4b5fd;">要素で絞り込む</div>
     <p style="margin: 0 0 8px 0; font-size: 15px;">複数選ぶと、選んだ要素が全部そろって紐づいているアイデアだけに絞り込まれます。</p>
 
-    <%= form_with url: search_path, method: :get, local: true do %>
+    <%= form_with url: search_path, method: :get, local: true,
+                  data: { controller: "element-selector", action: "change->element-selector#refresh" } do %>
       <%= hidden_field_tag :q, params[:q] if params[:q].present? %>
       <%= hidden_field_tag :scope, params[:scope] if params[:scope].present? %>
       <%= hidden_field_tag :within_story, "1" %>
@@ -57,6 +58,23 @@
       <%= hidden_field_tag "search_story_element_ids[]", "" %>
 
       <% grouped_elements = @story.story_elements.group_by(&:kind) %>
+
+      <%# チェックした瞬間、押す前でもここに選んだ要素がタグで表示される %>
+      <div style="margin-bottom: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff; max-width: 420px;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px; color: #ddd6fe;">
+          選択中の要素
+        </div>
+
+        <p data-element-selector-target="emptyMessage" style="margin: 0; color: #cccccc;">
+          まだ選択されていません
+        </p>
+
+        <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="setting" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="place" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="organization" hidden style="color: #ffffff;"></div>
+      </div>
 
       <div style="border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff; max-width: 420px;">
         <%# 要素数が増えても縦に長くなりすぎないよう、分類ごとに開閉できるようにする %>
@@ -85,7 +103,12 @@
                   <%= check_box_tag "search_story_element_ids[]",
                         element.id,
                         @selected_story_element_ids.include?(element.id),
-                        id: checkbox_id %>
+                        id: checkbox_id,
+                        data: {
+                          "element-selector-target": "checkbox",
+                          kind: element.kind,
+                          label: truncate("#{element.marker}　#{element.name}", length: 40)
+                        } %>
 
                   <label for="<%= checkbox_id %>" style="cursor: pointer; margin-bottom: 0; color: #ffffff;">
                     <%= truncate("#{element.marker}　#{element.name}", length: 40) %>

--- a/app/views/stories/consistency.html.erb
+++ b/app/views/stories/consistency.html.erb
@@ -50,7 +50,8 @@
      "[#{kind_label_for.call(element)}]#{element.try(:marker)}　#{element.name}"
    end %>
 
-<%= form_with url: consistency_story_path(@story), method: :get, local: true do %>
+<%= form_with url: consistency_story_path(@story), method: :get, local: true,
+              data: { controller: "element-selector", action: "change->element-selector#refresh" } do %>
   <%= hidden_field_tag :from, params[:from] if params[:from].present? %>
   <%= hidden_field_tag :story_event_id, params[:story_event_id] if params[:story_event_id].present? %>
   <%= hidden_field_tag :story_event_idea_id, params[:story_event_idea_id] if params[:story_event_idea_id].present? %>
@@ -62,6 +63,23 @@
       <p style="color: #cccccc;">要素がまだありません（先に要素を作成してください）</p>
     <% else %>
       <% grouped_elements = @elements.group_by(&:kind) %>
+
+      <%# チェックした瞬間、押す前でもここに選んだ要素がタグで表示される %>
+      <div style="margin-top: 12px; margin-bottom: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px; color: #ddd6fe;">
+          選択中の要素
+        </div>
+
+        <p data-element-selector-target="emptyMessage" style="margin: 0; color: #cccccc;">
+          まだ選択されていません
+        </p>
+
+        <div data-element-selector-target="summary" data-kind="character" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="item" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="setting" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="place" hidden style="margin-bottom: 16px; color: #ffffff;"></div>
+        <div data-element-selector-target="summary" data-kind="organization" hidden style="color: #ffffff;"></div>
+      </div>
 
       <div style="margin-top: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
         <%# 分類ごとに開閉できるようにする。要素が増えても一覧が縦に長くなりすぎないようにするため %>
@@ -91,7 +109,12 @@
                   <%= check_box_tag "consistency_story_element_ids[]",
                         element.id,
                         @selected_elements.any? { |selected| selected.id == element.id },
-                        id: checkbox_id %>
+                        id: checkbox_id,
+                        data: {
+                          "element-selector-target": "checkbox",
+                          kind: element.kind,
+                          label: truncate(element_label_for.call(element), length: 40)
+                        } %>
 
                   <label for="<%= checkbox_id %>" style="cursor: pointer; margin-bottom: 0; color: #ffffff;">
                     <%= truncate(element_label_for.call(element), length: 40) %>
@@ -114,7 +137,7 @@
 <hr style="border: none; border-top: 1px solid #444444; margin: 20px 0;">
 
 <% if @selected_elements.present? %>
-  <div style="font-size: 20px; font-weight: bold; margin-bottom: 8px; color: #c4b5fd;">選択中の要素</div>
+  <div style="font-size: 20px; font-weight: bold; margin-bottom: 8px; color: #c4b5fd;">選択した要素の詳細</div>
 
   <% @selected_elements.each do |selected_element| %>
     <% element_memo = selected_element.try(:memo) ||

--- a/app/views/stories/consistency.html.erb
+++ b/app/views/stories/consistency.html.erb
@@ -66,9 +66,12 @@
 
       <%# チェックした瞬間、押す前でもここに選んだ要素がタグで表示される %>
       <div style="margin-top: 12px; margin-bottom: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
-        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px; color: #ddd6fe;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 4px; color: #ddd6fe;">
           選択中の要素
         </div>
+        <p style="margin: 0 0 12px 0; font-size: 14px; color: #cccccc;">
+          ×を押すと、その要素の選択を解除できます。
+        </p>
 
         <p data-element-selector-target="emptyMessage" style="margin: 0; color: #cccccc;">
           まだ選択されていません

--- a/app/views/story_event_ideas/_form.html.erb
+++ b/app/views/story_event_ideas/_form.html.erb
@@ -61,9 +61,12 @@
       <% grouped_elements = StoryElement.sorted_by_kind_and_name(@story.story_elements).group_by(&:kind) %>
 
       <div style="margin-top: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
-        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px; color: #ddd6fe;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 4px; color: #ddd6fe;">
           選択中の要素
         </div>
+        <p style="margin: 0 0 12px 0; font-size: 14px; color: #cccccc;">
+          ×を押すと、その要素の選択を解除できます。
+        </p>
 
         <p data-element-selector-target="emptyMessage" style="margin: 0; color: #cccccc;">
           まだ選択されていません

--- a/app/views/story_events/_form.html.erb
+++ b/app/views/story_events/_form.html.erb
@@ -66,9 +66,12 @@
       <% grouped_elements = StoryElement.sorted_by_kind_and_name(@story.story_elements).group_by(&:kind) %>
 
       <div style="margin-top: 12px; border: 1px solid #555555; border-radius: 8px; padding: 16px; background: #1e1e1e; color: #ffffff;">
-        <div style="font-size: 20px; font-weight: bold; margin-bottom: 16px; color: #ddd6fe;">
+        <div style="font-size: 20px; font-weight: bold; margin-bottom: 4px; color: #ddd6fe;">
           選択中の要素
         </div>
+        <p style="margin: 0 0 12px 0; font-size: 14px; color: #cccccc;">
+          ×を押すと、その要素の選択を解除できます。
+        </p>
 
         <p data-element-selector-target="emptyMessage" style="margin: 0; color: #cccccc;">
           まだ選択されていません

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -58,6 +58,62 @@ RSpec.describe "Searches", type: :request do
       expect(response.body).to include("この作品内（ポケモン）")
     end
 
+    describe "要素での絞り込み（複数選択）" do
+      let(:story) { create(:story, user: user, title: "検索絞り込み確認用") }
+      let(:element_a) { create(:story_element, story: story, kind: "character", name: "アリス") }
+      let(:element_b) { create(:story_element, story: story, kind: "character", name: "ボブ") }
+
+      def idea_linked_to(story, user, *elements)
+        idea = create(:idea, user: user, title: "対象アイデア", memo: "m")
+        placement = create(:idea_placement, idea: idea, placeable: story, created_here: true)
+        placement.story_element_ids = elements.map(&:id)
+        idea
+      end
+
+      it "ヘッダーで選んだ要素1個がそのまま結果に反映される（後方互換）" do
+        idea_linked_to(story, user, element_a)
+
+        get search_path, params: {
+          q: "対象", scope: "all", within_story: "1", story_id: story.id, story_element_id: element_a.id
+        }
+
+        expect(response.body).to include("対象アイデア")
+      end
+
+      it "結果ページで複数チェックすると、全部そろって紐づくアイデアだけに絞り込まれる" do
+        idea_linked_to(story, user, element_a, element_b)
+
+        get search_path, params: {
+          q: "対象", scope: "all", within_story: "1", story_id: story.id,
+          search_story_element_ids: [element_a.id, element_b.id]
+        }
+
+        expect(response.body).to include("対象アイデア")
+      end
+
+      it "一部の要素しか紐づいていないアイデアは、複数選ぶと表示されなくなる" do
+        idea_linked_to(story, user, element_a)
+
+        get search_path, params: {
+          q: "対象", scope: "all", within_story: "1", story_id: story.id,
+          search_story_element_ids: [element_a.id, element_b.id]
+        }
+
+        expect(response.body).not_to include("対象アイデア")
+      end
+
+      it "結果ページでチェックを全部外すと絞り込みが解除される" do
+        idea_linked_to(story, user, element_a)
+
+        get search_path, params: {
+          q: "対象", scope: "all", within_story: "1", story_id: story.id,
+          search_story_element_ids: [""]
+        }
+
+        expect(response.body).to include("対象アイデア")
+      end
+    end
+
     it "作品内ONではホーム未所属が結果に混ざらない（ストーリー内だけ出る）" do
       story = create(:story, user: user, title: "ポケモン")
 

--- a/spec/services/search/query_spec.rb
+++ b/spec/services/search/query_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Search::Query, type: :service do
   let(:user) { create(:user) }
 
   # rubocop:disable Naming/MethodParameterName
-  def call(q:, scope: "all", story_id: nil, story_element_id: nil)
+  def call(q:, scope: "all", story_id: nil, story_element_ids: [])
     described_class.new(
       q: q,
       scope: scope,
       story_id: story_id,
-      story_element_id: story_element_id,
+      story_element_ids: story_element_ids,
       user: user
     ).call
   end
@@ -38,6 +38,51 @@ RSpec.describe Search::Query, type: :service do
       result = call(q: "きりん", scope: "home")
 
       expect(result[:home][:created_here]).to be_empty
+    end
+  end
+
+  describe "要素での絞り込み" do
+    let(:story) { create(:story, user: user) }
+    let(:element_a) { create(:story_element, story: story, kind: "character", name: "キャラA") }
+    let(:element_b) { create(:story_element, story: story, kind: "character", name: "キャラB") }
+
+    def idea_linked_to(*elements)
+      idea = create(:idea, user: user, title: "対象アイデア", memo: "m")
+      placement = create(:idea_placement, idea: idea, placeable: story, created_here: true)
+      placement.story_element_ids = elements.map(&:id)
+      idea
+    end
+
+    it "要素を1つ指定すると、従来通りその要素が紐づくアイデアが見つかる" do
+      idea = idea_linked_to(element_a)
+
+      result = call(q: "対象", scope: "story", story_element_ids: [element_a.id])
+
+      expect(result[:story][:created_here]).to include(idea)
+    end
+
+    it "複数指定すると、選んだ要素が全部そろって紐づいているアイデアが見つかる" do
+      idea_both = idea_linked_to(element_a, element_b)
+
+      result = call(q: "対象", scope: "story", story_element_ids: [element_a.id, element_b.id])
+
+      expect(result[:story][:created_here]).to include(idea_both)
+    end
+
+    it "複数指定すると、一部の要素しか紐づいていないアイデアは見つからない" do
+      idea_only_a = idea_linked_to(element_a)
+
+      result = call(q: "対象", scope: "story", story_element_ids: [element_a.id, element_b.id])
+
+      expect(result[:story][:created_here]).not_to include(idea_only_a)
+    end
+
+    it "選んだ要素が全部そろって紐づいているアイデアが無ければ見つからない" do
+      idea_linked_to(element_a)
+
+      result = call(q: "対象", scope: "story", story_element_ids: [element_a.id, element_b.id])
+
+      expect(result[:story][:created_here]).to be_empty
     end
   end
 


### PR DESCRIPTION
## 概要

検索結果ページでも要素を複数選んで絞り込めるようにし、あわせて要素選択UI全体の使い勝手を改善しました。

## 変更内容

### 検索の複数要素AND絞り込み
- ヘッダーの要素選択（1個だけ）はそのまま変更せず、検索結果ページ内に新しく
  「要素で絞り込む」チェックボックス欄を追加（分類ごとに開閉可能）
- ヘッダーで選んだ1個は、結果ページのチェック欄に初期状態として引き継がれる
- 結果ページで複数チェックして絞り込むと、選んだ要素が全部そろって紐づいている
  アイデアだけに絞り込まれる（整合性チェックと同じAND条件、GROUP BY + HAVING）
- 1個だけ選んだ場合は従来通りの結果になり後方互換

### 「選択中の要素」欄の改善（イベント追加・詳細メモ追加・アイデア作成・整合性チェック・検索結果、全5画面）
- 整合性チェック・検索結果にも、チェックした瞬間（送信前）に選んだ要素がタグで
  表示される「選択中の要素」欄を追加（既存のelement_selector_controller.jsを再利用）
- タグ自体をクリックすると、対応するチェックボックスのチェックが外れてその場で
  選択解除できるように変更（共有JSファイルの変更のみで全5画面に反映）
- 選択解除用の×を、文字色と同化して見えにくいという指摘を受けて赤色
  （既存の削除注意文と同じ#f87171）に変更
- 「×を押すと解除できます」という説明文を全5画面に追加

## 検証内容

- rspec 全件（103件）パス、RuboCop offenseなし
- ブラウザで実データを使い、以下を確認
  - 検索結果ページでの単一選択（後方互換）・複数選択AND・チェック解除
  - イベント追加ページ・整合性チェックページでの「チェック→タグ表示→タグクリックで解除」
  - ×の色（JSで computed style を確認）
  - 説明文の表示
- 実装中に見つけたバグ2件（MySQLのONLY_FULL_GROUP_BYエラー、`.group`後の`.count`が
  Hashを返す問題）はその場で修正・再確認済み

## 備考（正直な自己申告）

検索結果ページの「タグクリックで選択解除」は、実装後にブラウザタブが不安定になり
目視での最終確認ができていません。イベント追加・整合性チェックページと全く同じ
JS・HTML構造を使っているため動作するはずですが、その旨を申し添えます。