### PR TITLE
検索の複数要素絞り込みで本番(PostgreSQL)エラーが出る不具合を修正

### DIFF
--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -61,15 +61,21 @@ module Search
     end
 
     # 選んだ要素が全部そろって紐づいているアイデアだけに絞り込む（AND条件）。
-    # GROUP BY + HAVINGで絞り込んだ後にcreated_hereでの分岐・並び替えを続けても
-    # 崩れないことは確認済み（idsが1個の場合は今までと同じ結果になる）
+    # GROUP BY + HAVINGで一致するIDだけを求め、そのIDで別クエリを読み直す2段階構成。
+    # GROUP BYした結果に対してcreated_here分岐やidea_placements.moved_atでの
+    # 並び替えをそのまま続けると、別テーブルの列で並び替えることになり、
+    # PostgreSQL・MySQL(ONLY_FULL_GROUP_BY)いずれでもエラーになるため分離した
     def apply_story_element_filter(rel)
       return rel if @story_element_ids.blank?
 
-      rel.joins(idea_placement: :idea_placement_elements)
-         .where(idea_placement_elements: { story_element_id: @story_element_ids })
-         .group("ideas.id")
-         .having("COUNT(DISTINCT idea_placement_elements.story_element_id) = ?", @story_element_ids.size)
+      matching_ids =
+        rel.joins(idea_placement: :idea_placement_elements)
+           .where(idea_placement_elements: { story_element_id: @story_element_ids })
+           .group("ideas.id")
+           .having("COUNT(DISTINCT idea_placement_elements.story_element_id) = ?", @story_element_ids.size)
+           .pluck("ideas.id")
+
+      rel.where(ideas: { id: matching_ids })
     end
 
     def build_home

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe "Searches", type: :request do
       let(:element_a) { create(:story_element, story: story, kind: "character", name: "アリス") }
       let(:element_b) { create(:story_element, story: story, kind: "character", name: "ボブ") }
 
-      def idea_linked_to(story, user, *elements)
+      def idea_linked_to(story, user, *elements, created_here: true)
         idea = create(:idea, user: user, title: "対象アイデア", memo: "m")
-        placement = create(:idea_placement, idea: idea, placeable: story, created_here: true)
+        placement = create(:idea_placement, idea: idea, placeable: story, created_here: created_here)
         placement.story_element_ids = elements.map(&:id)
         idea
       end
@@ -110,6 +110,21 @@ RSpec.describe "Searches", type: :request do
           search_story_element_ids: [""]
         }
 
+        expect(response.body).to include("対象アイデア")
+      end
+
+      # 移動してきたアイデアはidea_placements.moved_atで並び替えており、
+      # 要素の複数指定と組み合わせた時に画面が壊れないことを確認する
+      # （本番のPostgreSQLでGROUP BY関連のエラーが実際に発生したための回帰テスト）
+      it "移動してきたアイデアも、複数の要素で絞り込んだ画面に正常に表示される" do
+        idea_linked_to(story, user, element_a, element_b, created_here: false)
+
+        get search_path, params: {
+          q: "対象", scope: "all", within_story: "1", story_id: story.id,
+          search_story_element_ids: [element_a.id, element_b.id]
+        }
+
+        expect(response).to have_http_status(:ok)
         expect(response.body).to include("対象アイデア")
       end
     end

--- a/spec/services/search/query_spec.rb
+++ b/spec/services/search/query_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe Search::Query, type: :service do
     let(:element_a) { create(:story_element, story: story, kind: "character", name: "キャラA") }
     let(:element_b) { create(:story_element, story: story, kind: "character", name: "キャラB") }
 
-    def idea_linked_to(*elements)
+    def idea_linked_to(*elements, created_here: true)
       idea = create(:idea, user: user, title: "対象アイデア", memo: "m")
-      placement = create(:idea_placement, idea: idea, placeable: story, created_here: true)
+      placement = create(:idea_placement, idea: idea, placeable: story, created_here: created_here)
       placement.story_element_ids = elements.map(&:id)
       idea
     end
@@ -83,6 +83,17 @@ RSpec.describe Search::Query, type: :service do
       result = call(q: "対象", scope: "story", story_element_ids: [element_a.id, element_b.id])
 
       expect(result[:story][:created_here]).to be_empty
+    end
+
+    # 移動してきたアイデア(moved)は、created_hereとは別テーブルの列(moved_at)で
+    # 並び替えている。要素の複数指定と組み合わせたときにエラーにならないことを確認する
+    # (本番のPostgreSQLでGROUP BY関連のエラーが実際に発生したための回帰テスト)
+    it "移動してきたアイデアも、複数の要素で絞り込める" do
+      idea_moved = idea_linked_to(element_a, element_b, created_here: false)
+
+      result = call(q: "対象", scope: "story", story_element_ids: [element_a.id, element_b.id])
+
+      expect(result[:story][:moved]).to include(idea_moved)
     end
   end
 


### PR DESCRIPTION
本番で発生した実際のエラー:
  PG::GroupingError: column "idea_placements.moved_at" must appear in
  the GROUP BY clause or be used in an aggregate function

原因:
  Search::Query#apply_story_element_filterがGROUP BY(ideas.id)した結果に
  対して、呼び出し元のsplit_created_movedが「移動してきたアイデア」側で
  別テーブルの列(idea_placements.moved_at)を使って並び替えていた。
  MySQLは1対1のユニーク関連を通じて推移的に依存関係を認識し許可するが、
  PostgreSQLはその緩和を行わないため、本番でのみエラーになっていた。
  （ローカル開発環境のMySQLでは再現しなかったため、テストで見逃していた）

修正:
  整合性チェックで使ったのと同じ「GROUP BY + HAVINGで一致するIDだけ求め、
  そのIDで別クエリを読み直す」2段階構成に変更。GROUP BYを呼び出し元に
  見せない形にすることで、どのテーブルの列で並び替えても安全になる。

検証:
  - 修正前のコードでは、ローカルに一時的に用意したPostgreSQLコンテナで 本番と全く同じエラーメッセージが再現することを確認
  - 修正後のコードでは、同じPostgreSQL環境で正常に動作することを確認
  - 「移動してきたアイデア」×「複数要素絞り込み」の組み合わせの回帰テストを query_spec.rb・searches_spec.rbの両方に追加
  - 既存のrspec全件(105件)・RuboCopも問題なし